### PR TITLE
Redesign auth page with unified modal

### DIFF
--- a/web/app/auth/AuthGate.tsx
+++ b/web/app/auth/AuthGate.tsx
@@ -9,11 +9,13 @@ type AuthGateProps = {
 };
 
 type View = 'signin' | 'new_password' | 'forgot_password' | 'reset_password';
+type AuthMode = 'waitlist' | 'login';
 
 export default function AuthGate({ children, onAuthenticated }: AuthGateProps): JSX.Element {
   const [ready, setReady] = useState(false);
   const [user, setUser] = useState<any>(null);
   const [view, setView] = useState<View>('signin');
+  const [authMode, setAuthMode] = useState<AuthMode>('waitlist');
   const [signInEmail, setSignInEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -98,6 +100,26 @@ export default function AuthGate({ children, onAuthenticated }: AuthGateProps): 
       }
     })();
   }, [completeSignIn]);
+
+  // Detect if coming from checkout flow and set default mode
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    // Check if we have a checkout session in storage
+    const checkoutData = window.sessionStorage.getItem('checkoutSession');
+    if (checkoutData) {
+      setAuthMode('login');
+      return;
+    }
+
+    // Check URL parameters for checkout-related indicators
+    const urlParams = new URLSearchParams(window.location.search);
+    const checkoutParam = urlParams.get('checkout') || urlParams.get('payment_success');
+    if (checkoutParam) {
+      setAuthMode('login');
+      return;
+    }
+  }, []);
 
   if (!ready) return <div style={{ padding: 24 }}>Loading…</div>;
   if (user) return <>{children}</>;
@@ -190,258 +212,278 @@ export default function AuthGate({ children, onAuthenticated }: AuthGateProps): 
   };
 
   return (
-    <section className="section" id="signup" style={{ maxWidth: 900, margin: '0 auto' }}>
-      <div className="signup-stack">
-        <div className="waitlist-card" style={{ width: '100%', maxWidth: 520 }}>
-          <div className="waitlist-header">
-            <img src="/assets/SpaceportIcons/SpaceportFullLogoWhite.svg" alt="Spaceport AI" className="waitlist-logo" />
-            <h2>New here?</h2>
-            <p>Join the waitlist to be among the first to access Spaceport AI.</p>
-          </div>
-          <form onSubmit={joinWaitlist} className="waitlist-form">
-            <div className="input-group">
-              <input className="waitlist-input" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
-            </div>
-            <div className="input-group">
-              <input className="waitlist-input" placeholder="Email Address" type="email" value={waitlistEmail} onChange={(e) => setWaitlistEmail(e.target.value)} />
-            </div>
-            <button type="submit" className="waitlist-submit-btn" disabled={waitlistSubmitting}>
-              <span>{waitlistSubmitting ? 'Submitting…' : 'Join Waitlist'}</span>
-              <div className="spinner" style={{ display: waitlistSubmitting ? 'inline-block' : 'none', marginLeft: 8 }} />
-            </button>
-          </form>
+    <section className="section" id="signup" style={{ maxWidth: 900, margin: '0 auto', minHeight: '60vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div className="auth-modal">
+        {/* Mode Toggle */}
+        <div className="auth-mode-toggle">
+          <button
+            type="button"
+            className={`auth-mode-button ${authMode === 'waitlist' ? 'active' : ''}`}
+            onClick={() => setAuthMode('waitlist')}
+          >
+            Sign Up for Waitlist
+          </button>
+          <button
+            type="button"
+            className={`auth-mode-button ${authMode === 'login' ? 'active' : ''}`}
+            onClick={() => setAuthMode('login')}
+          >
+            Login
+          </button>
         </div>
 
-        <div className="signin-block" style={{ width: '100%', maxWidth: 520 }}>
-          <div className="waitlist-card" style={{ width: '100%' }}>
-            <div className="waitlist-header">
-              <h2>Sign in to create your model</h2>
-            </div>
-            
-            {/* Sign In View */}
-            {view === 'signin' && (
-              <form onSubmit={signIn} className="waitlist-form">
-                <div className="input-group">
-                  <input 
-                    value={signInEmail} 
-                    onChange={(e) => setSignInEmail(e.target.value)} 
-                    type="email" 
-                    className="waitlist-input" 
-                    placeholder="Email" 
-                    required 
-                  />
-                </div>
-                <div className="input-group" style={{ position: 'relative' }}>
-                  <input 
-                    value={password} 
-                    onChange={(e) => setPassword(e.target.value)} 
-                    type={showPassword ? 'text' : 'password'} 
-                    className="waitlist-input" 
-                    placeholder="Password" 
-                    required 
-                  />
-                  <button
-                    type="button"
-                    aria-label={showPassword ? 'Hide password' : 'Show password'}
-                    onClick={() => setShowPassword((v) => !v)}
-                    style={{ position: 'absolute', right: 16, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 0, padding: 0, cursor: 'pointer' }}
-                  >
-                    <EyeIcon hidden={showPassword} />
-                  </button>
-                </div>
-                {error && <p style={{ color: '#ff6b6b', fontSize: '14px', marginTop: '8px' }}>{error}</p>}
-                {successMessage && <p style={{ color: '#4CAF50', fontSize: '14px', marginTop: '8px' }}>{successMessage}</p>}
-                <button className="waitlist-submit-btn" type="submit" disabled={isLoading}>
-                  <span>{isLoading ? 'Signing in...' : 'Sign in'}</span>
-                  {isLoading && <div className="spinner" style={{ display: 'inline-block', marginLeft: 8 }} />}
-                </button>
-                <div style={{ textAlign: 'center', marginTop: '16px' }}>
-                  <button
-                    type="button"
-                    onClick={() => setView('forgot_password')}
-                    style={{
-                      background: 'transparent',
-                      border: 'none',
-                      color: '#4CAF50',
-                      textDecoration: 'underline',
-                      cursor: 'pointer',
-                      fontSize: '14px'
-                    }}
-                  >
-                    Forgot your password?
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {/* Forgot Password View */}
-            {view === 'forgot_password' && (
-              <form onSubmit={handleForgotPassword} className="waitlist-form">
-                <p style={{ marginBottom: '16px', fontSize: '14px', color: '#666' }}>
-                  Enter your email address and we'll send you a code to reset your password.
-                </p>
-                <div className="input-group">
-                  <input 
-                    value={forgotEmail} 
-                    onChange={(e) => setForgotEmail(e.target.value)} 
-                    type="email" 
-                    className="waitlist-input" 
-                    placeholder="Email address" 
-                    required 
-                  />
-                </div>
-                {error && <p style={{ color: '#ff6b6b', fontSize: '14px', marginTop: '8px' }}>{error}</p>}
-                <button className="waitlist-submit-btn" type="submit" disabled={isLoading}>
-                  <span>{isLoading ? 'Sending...' : 'Send reset code'}</span>
-                  {isLoading && <div className="spinner" style={{ display: 'inline-block', marginLeft: 8 }} />}
-                </button>
-                <div style={{ textAlign: 'center', marginTop: '16px' }}>
-                  <button
-                    type="button"
-                    onClick={resetForm}
-                    style={{
-                      background: 'transparent',
-                      border: 'none',
-                      color: '#4CAF50',
-                      textDecoration: 'underline',
-                      cursor: 'pointer',
-                      fontSize: '14px'
-                    }}
-                  >
-                    Back to sign in
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {/* Reset Password View */}
-            {view === 'reset_password' && (
-              <form onSubmit={handleResetPassword} className="waitlist-form">
-                <p style={{ marginBottom: '16px', fontSize: '14px', color: '#666' }}>
-                  Enter the code from your email and choose a new password.
-                </p>
-                <div className="input-group">
-                  <input 
-                    value={resetCode} 
-                    onChange={(e) => setResetCode(e.target.value)} 
-                    type="text" 
-                    className="waitlist-input" 
-                    placeholder="Reset code" 
-                    required 
-                    maxLength={6}
-                  />
-                </div>
-                <div className="input-group" style={{ position: 'relative' }}>
-                  <input 
-                    value={resetPassword} 
-                    onChange={(e) => setResetPassword(e.target.value)} 
-                    type={showResetPassword ? 'text' : 'password'} 
-                    className="waitlist-input" 
-                    placeholder="New password" 
-                    required 
-                    minLength={8}
-                  />
-                  <button
-                    type="button"
-                    aria-label={showResetPassword ? 'Hide password' : 'Show password'}
-                    onClick={() => setShowResetPassword((v) => !v)}
-                    style={{ position: 'absolute', right: 16, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 0, padding: 0, cursor: 'pointer' }}
-                  >
-                    <EyeIcon hidden={showResetPassword} />
-                  </button>
-                </div>
-                {error && <p style={{ color: '#ff6b6b', fontSize: '14px', marginTop: '8px' }}>{error}</p>}
-                <button className="waitlist-submit-btn" type="submit" disabled={isLoading}>
-                  <span>{isLoading ? 'Resetting...' : 'Reset password'}</span>
-                  {isLoading && <div className="spinner" style={{ display: 'inline-block', marginLeft: 8 }} />}
-                </button>
-                <div style={{ textAlign: 'center', marginTop: '16px' }}>
-                  <button
-                    type="button"
-                    onClick={() => setView('forgot_password')}
-                    style={{
-                      background: 'transparent',
-                      border: 'none',
-                      color: '#4CAF50',
-                      textDecoration: 'underline',
-                      cursor: 'pointer',
-                      fontSize: '14px'
-                    }}
-                  >
-                    Resend code
-                  </button>
-                </div>
-              </form>
+        {/* Modal Content */}
+        <div className="auth-modal-content">
+          <div className="auth-modal-header">
+            <img src="/assets/SpaceportIcons/SpaceportFullLogoWhite.svg" alt="Spaceport AI" className="auth-logo" />
+            {authMode === 'waitlist' ? (
+              <>
+                <h2>New here?</h2>
+                <p>Join the waitlist to be among the first to access Spaceport AI.</p>
+              </>
+            ) : (
+              <>
+                <h2>Sign in to create your model</h2>
+                <p>Welcome back! Sign in to access your account.</p>
+              </>
             )}
           </div>
 
-          {/* New Password Required View */}
-          {view === 'new_password' && (
-            <form
-              onSubmit={async (e) => {
-                e.preventDefault();
-                setError(null);
-                setIsLoading(true);
-                try {
-                  if (!pendingUser) throw new Error('Session expired');
-                  // First attempt: set password and preferred_username if provided (v3 pool supports this)
-                  const attrs: any = {};
-                  if (handle) attrs.preferred_username = handle;
-                  try {
-                    const completed = await Auth.completeNewPassword(pendingUser, newPassword, attrs);
-                    const current = await Auth.currentAuthenticatedUser();
-                    completeSignIn(current || completed);
-                  } catch (errInner: any) {
-                    const msg = (errInner?.message || '').toLowerCase();
-                    const code = (errInner?.name || errInner?.code || '').toString();
-                    const isPrefUsernameIssue =
-                      code === 'InvalidParameterException' ||
-                      msg.includes('preferred_username') ||
-                      msg.includes('mutability') ||
-                      msg.includes('invalid user attributes');
-                    if (isPrefUsernameIssue) {
-                      // Fallback for v2 pool where preferred_username is immutable; complete without attributes
-                      const completed = await Auth.completeNewPassword(pendingUser, newPassword);
-                      const current = await Auth.currentAuthenticatedUser();
-                      completeSignIn(current || completed);
-                    } else {
-                      throw errInner;
-                    }
-                  }
-                } catch (err: any) {
-                  const code = err?.name || err?.code || '';
-                  if (code === 'AliasExistsException') {
-                    setError('Username is taken. Please choose another.');
-                  } else {
-                    setError(err?.message || 'Failed to set password/handle');
-                  }
-                } finally {
-                  setIsLoading(false);
-                }
-              }}
-              className="waitlist-form"
-            >
-              <p>Finish setup by choosing your password and a unique handle.</p>
-              <div className="input-group" style={{ position: 'relative' }}>
-                <input value={newPassword} onChange={(e) => setNewPassword(e.target.value)} type={showNewPassword ? 'text' : 'password'} required className="waitlist-input" placeholder="New password" />
-                <button
-                  type="button"
-                  aria-label={showNewPassword ? 'Hide password' : 'Show password'}
-                  onClick={() => setShowNewPassword((v) => !v)}
-                  style={{ position: 'absolute', right: 16, top: '50%', transform: 'translateY(-50%)', background: 'transparent', border: 0, padding: 0, cursor: 'pointer' }}
-                >
-                  <EyeIcon hidden={showNewPassword} />
-                </button>
+          {/* Waitlist Form */}
+          {authMode === 'waitlist' && (
+            <form onSubmit={joinWaitlist} className="auth-form">
+              <div className="input-group">
+                <input
+                  className="auth-input"
+                  placeholder="Name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                />
               </div>
               <div className="input-group">
-                <input value={handle} onChange={(e) => setHandle(e.target.value)} required className="waitlist-input" placeholder="Handle (e.g. johndoe)" />
+                <input
+                  className="auth-input"
+                  placeholder="Email Address"
+                  type="email"
+                  value={waitlistEmail}
+                  onChange={(e) => setWaitlistEmail(e.target.value)}
+                  required
+                />
               </div>
-              {error && <p style={{ color: '#ff6b6b' }}>{error}</p>}
-              <button className="waitlist-submit-btn" type="submit" disabled={isLoading}>
-                <span>{isLoading ? 'Saving...' : 'Save and sign in'}</span>
-                {isLoading && <div className="spinner" style={{ display: 'inline-block', marginLeft: 8 }} />}
+              {error && <p className="auth-error">{error}</p>}
+              <button type="submit" className="auth-submit-btn" disabled={waitlistSubmitting}>
+                <span>{waitlistSubmitting ? 'Submitting…' : 'Join Waitlist'}</span>
+                {waitlistSubmitting && <div className="spinner" />}
               </button>
             </form>
+          )}
+
+          {/* Login Form */}
+          {authMode === 'login' && (
+            <>
+              {/* Sign In View */}
+              {view === 'signin' && (
+                <form onSubmit={signIn} className="auth-form">
+                  <div className="input-group">
+                    <input
+                      value={signInEmail}
+                      onChange={(e) => setSignInEmail(e.target.value)}
+                      type="email"
+                      className="auth-input"
+                      placeholder="Email"
+                      required
+                    />
+                  </div>
+                  <div className="input-group" style={{ position: 'relative' }}>
+                    <input
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      type={showPassword ? 'text' : 'password'}
+                      className="auth-input"
+                      placeholder="Password"
+                      required
+                    />
+                    <button
+                      type="button"
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      onClick={() => setShowPassword((v) => !v)}
+                      className="password-toggle"
+                    >
+                      <EyeIcon hidden={showPassword} />
+                    </button>
+                  </div>
+                  {error && <p className="auth-error">{error}</p>}
+                  {successMessage && <p className="auth-success">{successMessage}</p>}
+                  <button className="auth-submit-btn" type="submit" disabled={isLoading}>
+                    <span>{isLoading ? 'Signing in...' : 'Sign in'}</span>
+                    {isLoading && <div className="spinner" />}
+                  </button>
+                  <div className="auth-links">
+                    <button
+                      type="button"
+                      onClick={() => setView('forgot_password')}
+                      className="auth-link"
+                    >
+                      Forgot your password?
+                    </button>
+                  </div>
+                </form>
+              )}
+
+              {/* Forgot Password View */}
+              {view === 'forgot_password' && (
+                <form onSubmit={handleForgotPassword} className="auth-form">
+                  <p className="auth-description">
+                    Enter your email address and we'll send you a code to reset your password.
+                  </p>
+                  <div className="input-group">
+                    <input
+                      value={forgotEmail}
+                      onChange={(e) => setForgotEmail(e.target.value)}
+                      type="email"
+                      className="auth-input"
+                      placeholder="Email address"
+                      required
+                    />
+                  </div>
+                  {error && <p className="auth-error">{error}</p>}
+                  <button className="auth-submit-btn" type="submit" disabled={isLoading}>
+                    <span>{isLoading ? 'Sending...' : 'Send reset code'}</span>
+                    {isLoading && <div className="spinner" />}
+                  </button>
+                  <div className="auth-links">
+                    <button
+                      type="button"
+                      onClick={resetForm}
+                      className="auth-link"
+                    >
+                      Back to sign in
+                    </button>
+                  </div>
+                </form>
+              )}
+
+              {/* Reset Password View */}
+              {view === 'reset_password' && (
+                <form onSubmit={handleResetPassword} className="auth-form">
+                  <p className="auth-description">
+                    Enter the code from your email and choose a new password.
+                  </p>
+                  <div className="input-group">
+                    <input
+                      value={resetCode}
+                      onChange={(e) => setResetCode(e.target.value)}
+                      type="text"
+                      className="auth-input"
+                      placeholder="Reset code"
+                      required
+                      maxLength={6}
+                    />
+                  </div>
+                  <div className="input-group" style={{ position: 'relative' }}>
+                    <input
+                      value={resetPassword}
+                      onChange={(e) => setResetPassword(e.target.value)}
+                      type={showResetPassword ? 'text' : 'password'}
+                      className="auth-input"
+                      placeholder="New password"
+                      required
+                      minLength={8}
+                    />
+                    <button
+                      type="button"
+                      aria-label={showResetPassword ? 'Hide password' : 'Show password'}
+                      onClick={() => setShowResetPassword((v) => !v)}
+                      className="password-toggle"
+                    >
+                      <EyeIcon hidden={showResetPassword} />
+                    </button>
+                  </div>
+                  {error && <p className="auth-error">{error}</p>}
+                  <button className="auth-submit-btn" type="submit" disabled={isLoading}>
+                    <span>{isLoading ? 'Resetting...' : 'Reset password'}</span>
+                    {isLoading && <div className="spinner" />}
+                  </button>
+                  <div className="auth-links">
+                    <button
+                      type="button"
+                      onClick={() => setView('forgot_password')}
+                      className="auth-link"
+                    >
+                      Resend code
+                    </button>
+                  </div>
+                </form>
+              )}
+
+              {/* New Password Required View */}
+              {view === 'new_password' && (
+                <form
+                  onSubmit={async (e) => {
+                    e.preventDefault();
+                    setError(null);
+                    setIsLoading(true);
+                    try {
+                      if (!pendingUser) throw new Error('Session expired');
+                      const attrs: any = {};
+                      if (handle) attrs.preferred_username = handle;
+                      try {
+                        const completed = await Auth.completeNewPassword(pendingUser, newPassword, attrs);
+                        const current = await Auth.currentAuthenticatedUser();
+                        completeSignIn(current || completed);
+                      } catch (errInner: any) {
+                        const msg = (errInner?.message || '').toLowerCase();
+                        const code = (errInner?.name || errInner?.code || '').toString();
+                        const isPrefUsernameIssue =
+                          code === 'InvalidParameterException' ||
+                          msg.includes('preferred_username') ||
+                          msg.includes('mutability') ||
+                          msg.includes('invalid user attributes');
+                        if (isPrefUsernameIssue) {
+                          const completed = await Auth.completeNewPassword(pendingUser, newPassword);
+                          const current = await Auth.currentAuthenticatedUser();
+                          completeSignIn(current || completed);
+                        } else {
+                          throw errInner;
+                        }
+                      }
+                    } catch (err: any) {
+                      const code = err?.name || err?.code || '';
+                      if (code === 'AliasExistsException') {
+                        setError('Username is taken. Please choose another.');
+                      } else {
+                        setError(err?.message || 'Failed to set password/handle');
+                      }
+                    } finally {
+                      setIsLoading(false);
+                    }
+                  }}
+                  className="auth-form"
+                >
+                  <p className="auth-description">Finish setup by choosing your password and a unique handle.</p>
+                  <div className="input-group" style={{ position: 'relative' }}>
+                    <input value={newPassword} onChange={(e) => setNewPassword(e.target.value)} type={showNewPassword ? 'text' : 'password'} required className="auth-input" placeholder="New password" />
+                    <button
+                      type="button"
+                      aria-label={showNewPassword ? 'Hide password' : 'Show password'}
+                      onClick={() => setShowNewPassword((v) => !v)}
+                      className="password-toggle"
+                    >
+                      <EyeIcon hidden={showNewPassword} />
+                    </button>
+                  </div>
+                  <div className="input-group">
+                    <input value={handle} onChange={(e) => setHandle(e.target.value)} required className="auth-input" placeholder="Handle (e.g. johndoe)" />
+                  </div>
+                  {error && <p className="auth-error">{error}</p>}
+                  <button className="auth-submit-btn" type="submit" disabled={isLoading}>
+                    <span>{isLoading ? 'Saving...' : 'Save and sign in'}</span>
+                    {isLoading && <div className="spinner" />}
+                  </button>
+                </form>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -2456,6 +2456,291 @@ footer {
   font-weight: 500;
 }
 
+/* New Auth Modal Styles */
+.auth-modal {
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(50px);
+  -webkit-backdrop-filter: blur(50px);
+  border-radius: 25px;
+  padding: 32px;
+  max-width: 480px;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.auth-modal::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    145deg,
+    rgba(255,255,255,0.4) 0%,
+    rgba(255,255,255,0) 41%,
+    rgba(255,255,255,0) 57%,
+    rgba(255,255,255,0.4) 100%
+  );
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  padding: 1.4px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Mode Toggle */
+.auth-mode-toggle {
+  display: flex;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 4px;
+  margin-bottom: 32px;
+  position: relative;
+  z-index: 1;
+  gap: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.auth-mode-button {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-mode-button.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(255, 255, 255, 0.1);
+}
+
+.auth-mode-button:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+/* Modal Content */
+.auth-modal-content {
+  position: relative;
+  z-index: 1;
+}
+
+.auth-modal-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.auth-logo {
+  height: 32px;
+  width: auto;
+  margin-bottom: 24px;
+  opacity: 1;
+  filter: brightness(1) contrast(1);
+}
+
+.auth-modal-header h2 {
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-bottom: 12px;
+  color: #fff;
+  line-height: 1.2;
+}
+
+.auth-modal-header p {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+}
+
+/* Form Styles */
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.auth-input {
+  width: 100%;
+  padding: 16px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  font-size: 1rem;
+  transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.auth-input::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.auth-input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.1);
+}
+
+/* Password Toggle */
+.password-toggle {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.password-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.password-toggle svg path {
+  stroke: rgba(255, 255, 255, 0.5);
+}
+
+.password-toggle:hover svg path {
+  stroke: rgba(255, 255, 255, 0.8);
+}
+
+/* Submit Button */
+.auth-submit-btn {
+  background: linear-gradient(135deg, #FF4F00 0%, #FF6B35 100%);
+  color: #fff;
+  border: none;
+  padding: 16px 32px;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.auth-submit-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(255, 79, 0, 0.3);
+}
+
+.auth-submit-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.auth-submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Error and Success Messages */
+.auth-error {
+  color: #ff6b6b;
+  font-size: 14px;
+  margin: 0;
+  text-align: center;
+}
+
+.auth-success {
+  color: #4CAF50;
+  font-size: 14px;
+  margin: 0;
+  text-align: center;
+}
+
+/* Description Text */
+.auth-description {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0 0 20px 0;
+  text-align: center;
+}
+
+/* Auth Links */
+.auth-links {
+  text-align: center;
+  margin-top: 20px;
+}
+
+.auth-link {
+  background: transparent;
+  border: none;
+  color: #4CAF50;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 14px;
+  transition: color 0.3s ease;
+}
+
+.auth-link:hover {
+  color: #66BB6A;
+}
+
+/* Spinner */
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top: 2px solid #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Responsive adjustments for auth modal */
+@media (max-width: 768px) {
+  .auth-modal {
+    padding: 24px;
+    margin: 0 16px;
+  }
+
+  .auth-modal-header h2 {
+    font-size: 1.3rem;
+  }
+
+  .auth-modal-header p {
+    font-size: 0.9rem;
+  }
+
+  .auth-mode-button {
+    font-size: 0.8rem;
+    padding: 10px 16px;
+  }
+}
+
 /* Noise overlay layer for all three */
 #pricing-header::after,
 #about::after,


### PR DESCRIPTION
Redesign the Auth page to unify "Sign Up" and "Login" into a single, polished modal with a toggle, improving user experience and brand consistency.

The previous Auth page had separate, stacked sections for waitlist signup and login, which felt disjointed. This PR introduces a cohesive modal with a pill-shaped toggle, aligning with the desired clean, Apple-like design language and automatically defaulting to login for checkout flows, streamlining the user journey.

---
<a href="https://cursor.com/background-agent?bcId=bc-143f5586-aaa9-4158-a4e3-5adc5a342e79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-143f5586-aaa9-4158-a4e3-5adc5a342e79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

