### PR TITLE
[codex] Promote proven GPS-prior SfM fallback improvements

### DIFF
--- a/infrastructure/containers/sfm/run_colmap_sfm.py
+++ b/infrastructure/containers/sfm/run_colmap_sfm.py
@@ -7,17 +7,49 @@ import json
 import logging
 import os
 import shutil
+import sqlite3
+import struct
 import subprocess
 import sys
 import tempfile
 import time
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+WGS84_COORDINATE_SYSTEM = 0
+INF_COVARIANCE_BLOB = struct.pack("<9d", *([float("inf")] * 9))
+MATCH_PROFILES = {
+    "P1": {
+        "spatial_neighbors": 12,
+        "spatial_distance_m": 120.0,
+        "sequential_overlap": 8,
+    },
+    "P2": {
+        "spatial_neighbors": 14,
+        "spatial_distance_m": 140.0,
+        "sequential_overlap": 8,
+    },
+    "P3": {
+        "spatial_neighbors": 16,
+        "spatial_distance_m": 160.0,
+        "sequential_overlap": 10,
+    },
+}
+
+
+@dataclass
+class ModelSummary:
+    stage: str
+    text_dir: Path
+    cameras_registered: int
+    images_registered: int
+    points_3d: int
 
 
 def log_memory(stage: str) -> None:
@@ -63,14 +95,34 @@ def stream_command(command: List[str], *, stage: str, env: Dict[str, str] | None
         raise RuntimeError(f"{stage} failed with exit code {return_code}\n{tail}")
 
 
+def pack_float64_blob(values: Iterable[float]) -> bytes:
+    packed_values = [float(value) for value in values]
+    return struct.pack(f"<{len(packed_values)}d", *packed_values)
+
+
+def model_sort_key(model: ModelSummary) -> tuple[int, int, int]:
+    return (model.images_registered, model.points_3d, model.cameras_registered)
+
+
+def sort_capture_records(records: Iterable[dict[str, str]]) -> List[dict[str, str]]:
+    def record_key(record: dict[str, str]) -> tuple[int, str, str]:
+        capture_time = record.get("capture_time", "")
+        file_name = record.get("file_name", "")
+        if capture_time:
+            return (0, capture_time, file_name.lower())
+        return (1, file_name.lower(), "")
+
+    return sorted(records, key=record_key)
+
+
 class ColmapPipeline:
     def __init__(self, input_dir: Path, output_dir: Path) -> None:
         self.input_dir = Path(input_dir)
         self.output_dir = Path(output_dir)
         self.work_dir = Path(tempfile.mkdtemp(prefix="colmap_sfm_"))
         self.images_dir = self.work_dir / "images"
+        self.image_list_path = self.work_dir / "image_list.txt"
         self.database_path = self.work_dir / "database.db"
-        self.sparse_root = self.work_dir / "sparse"
         self.vocab_tree_path = Path(
             os.environ.get(
                 "COLMAP_VOCAB_TREE_PATH",
@@ -79,11 +131,19 @@ class ColmapPipeline:
         )
         self.generated_vocab_tree_path = self.work_dir / "vocab_tree_faiss.bin"
         self.active_vocab_tree_path: Path | None = None
-        self.vocab_tree_url = os.environ.get(
-            "COLMAP_VOCAB_TREE_URL",
-            "",
-        )
+        self.vocab_tree_url = os.environ.get("COLMAP_VOCAB_TREE_URL", "")
         self.use_gpu = os.environ.get("COLMAP_USE_GPU", "1") != "0"
+        self.enable_spatial_matcher = os.environ.get("COLMAP_ENABLE_SPATIAL_MATCHER", "1") != "0"
+        self.enable_sequential_matcher = (
+            os.environ.get("COLMAP_ENABLE_SEQUENTIAL_MATCHER", "1") != "0"
+        )
+        self.force_gps_first = os.environ.get("COLMAP_FORCE_GPS_FIRST", "1") != "0"
+        requested_match_profile = os.environ.get("COLMAP_MATCH_PROFILE", "P1").strip().upper() or "P1"
+        if requested_match_profile not in MATCH_PROFILES:
+            raise RuntimeError(
+                f"Unsupported COLMAP_MATCH_PROFILE={requested_match_profile}; expected one of {sorted(MATCH_PROFILES)}"
+            )
+        profile_defaults = MATCH_PROFILES[requested_match_profile]
         self.max_features = int(os.environ.get("COLMAP_SIFT_MAX_NUM_FEATURES", "8192"))
         self.vocab_num_images = int(os.environ.get("COLMAP_VOCAB_NUM_IMAGES", "40"))
         self.vocab_num_visual_words = int(
@@ -96,27 +156,72 @@ class ColmapPipeline:
             "COLMAP_VOCAB_BUILD_THREADS",
             os.environ.get("COLMAP_MAPPER_THREADS", "-1"),
         )
-        self.spatial_neighbors = int(os.environ.get("COLMAP_SPATIAL_MAX_NEIGHBORS", "24"))
-        self.spatial_distance_m = float(os.environ.get("COLMAP_SPATIAL_MAX_DISTANCE_METERS", "150"))
+        self.spatial_neighbors = int(
+            os.environ.get(
+                "COLMAP_SPATIAL_MAX_NEIGHBORS",
+                str(profile_defaults["spatial_neighbors"]),
+            )
+        )
+        self.spatial_distance_m = float(
+            os.environ.get(
+                "COLMAP_SPATIAL_MAX_DISTANCE_METERS",
+                str(profile_defaults["spatial_distance_m"]),
+            )
+        )
+        self.sequential_overlap = int(
+            os.environ.get(
+                "COLMAP_SEQUENTIAL_OVERLAP",
+                str(profile_defaults["sequential_overlap"]),
+            )
+        )
+        if (
+            self.enable_sequential_matcher
+            and self.spatial_neighbors == profile_defaults["spatial_neighbors"]
+            and self.spatial_distance_m == profile_defaults["spatial_distance_m"]
+            and self.sequential_overlap == profile_defaults["sequential_overlap"]
+        ):
+            self.match_profile = requested_match_profile
+        else:
+            self.match_profile = "custom"
+        self.gps_min_prior_coverage = float(os.environ.get("COLMAP_GPS_MIN_PRIOR_COVERAGE", "0.95"))
+        self.gps_min_registered_ratio = float(
+            os.environ.get("COLMAP_GPS_MIN_REGISTERED_RATIO", "0.98")
+        )
         self.mapper_threads = os.environ.get("COLMAP_MAPPER_THREADS", "-1")
         self.start_time = time.time()
         self.timings: Dict[str, float] = {}
+        self.dataset_image_count = 0
         self.gps_image_count = 0
+        self.pose_priors_written_count = 0
+        self.gps_prior_coverage = 0.0
+        self.pose_priors_source = "none"
+        self.exif_records: Dict[str, Dict[str, float | str]] = {}
+        self.capture_ordered_names: List[str] = []
         self.matchers_run: List[str] = []
+        self.matcher_pair_deltas: Dict[str, int] = {}
+        self.verified_pairs_total = 0
         self.vocab_tree_source = "uninitialized"
+        self.fallback_triggered = False
+        self.fallback_reason = "not_needed"
+        self.final_matcher_mode = "uninitialized"
+        self.gps_first_attempted = False
+        self.gps_first_skipped_reason = "uninitialized"
+        self.model_summaries: List[Dict[str, int | str]] = []
+        self.benchmark_subset_strategy = os.environ.get("SFM_BENCHMARK_SUBSET_STRATEGY", "")
         self.images_dir.mkdir(parents=True, exist_ok=True)
-        self.sparse_root.mkdir(parents=True, exist_ok=True)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
     def run(self) -> int:
         try:
             self.extract_images()
-            self.gps_image_count = self.count_images_with_gps()
-            self.ensure_vocab_tree()
+            self.exif_records = self.load_exif_records()
+            self.gps_image_count = len(self.exif_records)
+            self.prepare_capture_ordered_image_list()
             self.run_feature_extraction()
-            self.run_matching()
-            best_text_dir = self.run_mapper()
-            self.export_output(best_text_dir)
+            self.log_pose_prior_schema()
+            self.validate_or_backfill_pose_priors()
+            best_model = self.run_matching_and_mapping()
+            self.export_output(best_model)
             return 0
         except Exception as exc:
             logger.exception("COLMAP pipeline failed: %s", exc)
@@ -148,15 +253,20 @@ class ColmapPipeline:
                 image_count += 1
         if image_count == 0:
             raise RuntimeError("No images were found in the SfM input")
+        self.dataset_image_count = image_count
         self.timings["extract_images_seconds"] = round(time.time() - started, 2)
         logger.info("Extracted %s images", image_count)
 
-    def count_images_with_gps(self) -> int:
+    def load_exif_records(self) -> Dict[str, Dict[str, float | str]]:
         command = [
             "exiftool",
             "-j",
             "-n",
             "-r",
+            "-FileName",
+            "-DateTimeOriginal",
+            "-SubSecDateTimeOriginal",
+            "-CreateDate",
             "-GPSLatitude",
             "-GPSLongitude",
             "-GPSAltitude",
@@ -164,19 +274,227 @@ class ColmapPipeline:
         ]
         result = subprocess.run(command, capture_output=True, text=True, check=True)
         records = json.loads(result.stdout or "[]")
-        count = sum(
-            1
-            for record in records
-            if "GPSLatitude" in record and "GPSLongitude" in record
+        exif_records: Dict[str, Dict[str, float | str]] = {}
+        for record in records:
+            if "GPSLatitude" not in record or "GPSLongitude" not in record:
+                continue
+            file_name = record.get("FileName")
+            if not file_name:
+                continue
+            exif_records[file_name] = {
+                "file_name": file_name,
+                "gps_latitude": float(record["GPSLatitude"]),
+                "gps_longitude": float(record["GPSLongitude"]),
+                "gps_altitude": float(record.get("GPSAltitude", 0.0)),
+                "capture_time": (
+                    record.get("SubSecDateTimeOriginal")
+                    or record.get("DateTimeOriginal")
+                    or record.get("CreateDate")
+                    or ""
+                ),
+            }
+        logger.info("Detected GPS EXIF priors on %s images", len(exif_records))
+        return exif_records
+
+    def load_capture_records(self) -> List[dict[str, str]]:
+        command = [
+            "exiftool",
+            "-j",
+            "-FileName",
+            "-DateTimeOriginal",
+            "-SubSecDateTimeOriginal",
+            "-CreateDate",
+            str(self.images_dir),
+        ]
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        records = json.loads(result.stdout or "[]")
+        capture_records: List[dict[str, str]] = []
+        for record in records:
+            file_name = record.get("FileName")
+            if not file_name:
+                continue
+            capture_records.append(
+                {
+                    "file_name": file_name,
+                    "capture_time": (
+                        record.get("SubSecDateTimeOriginal")
+                        or record.get("DateTimeOriginal")
+                        or record.get("CreateDate")
+                        or ""
+                    ),
+                }
+            )
+        return capture_records
+
+    def prepare_capture_ordered_image_list(self) -> None:
+        capture_records = sort_capture_records(self.load_capture_records())
+        if capture_records:
+            self.capture_ordered_names = [record["file_name"] for record in capture_records]
+        else:
+            self.capture_ordered_names = sorted(
+                path.name
+                for path in self.images_dir.iterdir()
+                if path.suffix.lower() in {".jpg", ".jpeg", ".png"}
+            )
+        if not self.capture_ordered_names:
+            raise RuntimeError("Unable to determine image order for COLMAP processing")
+        with open(self.image_list_path, "w", encoding="utf-8") as handle:
+            for file_name in self.capture_ordered_names:
+                handle.write(f"{file_name}\n")
+        logger.info(
+            "Prepared image list with %s entries ordered by capture time then filename",
+            len(self.capture_ordered_names),
         )
-        logger.info("Detected GPS EXIF priors on %s images", count)
-        return count
+
+    def count_verified_pairs(self) -> int:
+        if not self.database_path.exists():
+            return 0
+        with sqlite3.connect(self.database_path) as connection:
+            row = connection.execute("SELECT COUNT(*) FROM two_view_geometries").fetchone()
+        return int(row[0] if row else 0)
+
+    def count_pose_priors(self) -> int:
+        if not self.database_path.exists():
+            return 0
+        with sqlite3.connect(self.database_path) as connection:
+            row = connection.execute("SELECT COUNT(*) FROM pose_priors").fetchone()
+        return int(row[0] if row else 0)
+
+    def get_image_ids_by_name(self) -> Dict[str, int]:
+        with sqlite3.connect(self.database_path) as connection:
+            rows = connection.execute("SELECT image_id, name FROM images").fetchall()
+        return {str(name): int(image_id) for image_id, name in rows}
+
+    def get_table_columns(self, table_name: str) -> set[str]:
+        with sqlite3.connect(self.database_path) as connection:
+            rows = connection.execute(f"PRAGMA table_info({table_name})").fetchall()
+        return {str(row[1]) for row in rows}
+
+    def pose_priors_columns(self) -> set[str]:
+        return self.get_table_columns("pose_priors")
+
+    def supports_pose_prior_image_backfill(self) -> bool:
+        return "image_id" in self.pose_priors_columns()
+
+    def pose_prior_schema_variant(self) -> str:
+        columns = self.pose_priors_columns()
+        if "image_id" in columns:
+            return "image_id"
+        if "pose_prior_id" in columns:
+            return "pose_prior_id"
+        return "unknown"
+
+    def log_pose_prior_schema(self) -> None:
+        logger.info(
+            "COLMAP pose_priors schema variant=%s columns=%s",
+            self.pose_prior_schema_variant(),
+            sorted(self.pose_priors_columns()),
+        )
+
+    def get_pose_prior_image_names(self) -> set[str]:
+        columns = self.pose_priors_columns()
+        if "image_id" not in columns:
+            logger.warning("COLMAP pose_priors table is missing image_id; columns=%s", sorted(columns))
+            return set()
+        with sqlite3.connect(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT images.name
+                FROM images
+                INNER JOIN pose_priors USING(image_id)
+                """
+            ).fetchall()
+        return {str(row[0]) for row in rows}
+
+    def backfill_pose_priors_from_exif(self) -> int:
+        if not self.exif_records:
+            return 0
+        if not self.supports_pose_prior_image_backfill():
+            logger.info("Skipping manual pose prior backfill for schema columns=%s", sorted(self.pose_priors_columns()))
+            return 0
+        image_ids_by_name = self.get_image_ids_by_name()
+        existing_names = self.get_pose_prior_image_names()
+        rows_to_insert: List[tuple[int, sqlite3.Binary, int, sqlite3.Binary]] = []
+        for file_name, record in self.exif_records.items():
+            image_id = image_ids_by_name.get(file_name)
+            if image_id is None or file_name in existing_names:
+                continue
+            position_blob = sqlite3.Binary(
+                pack_float64_blob(
+                    [
+                        float(record["gps_latitude"]),
+                        float(record["gps_longitude"]),
+                        float(record["gps_altitude"]),
+                    ]
+                )
+            )
+            rows_to_insert.append(
+                (
+                    image_id,
+                    position_blob,
+                    WGS84_COORDINATE_SYSTEM,
+                    sqlite3.Binary(INF_COVARIANCE_BLOB),
+                )
+            )
+        if not rows_to_insert:
+            return 0
+        with sqlite3.connect(self.database_path) as connection:
+            connection.executemany(
+                """
+                INSERT OR REPLACE INTO pose_priors (
+                    image_id,
+                    position,
+                    coordinate_system,
+                    position_covariance
+                ) VALUES (?, ?, ?, ?)
+                """,
+                rows_to_insert,
+            )
+            connection.commit()
+        logger.info("Backfilled %s COLMAP pose priors from EXIF metadata", len(rows_to_insert))
+        return len(rows_to_insert)
+
+    def validate_or_backfill_pose_priors(self) -> None:
+        if self.gps_image_count == 0:
+            self.pose_priors_source = "no_gps_exif"
+            self.pose_priors_written_count = 0
+            self.gps_prior_coverage = 0.0
+            return
+
+        before_backfill = self.count_pose_priors()
+        if before_backfill == 0 and self.supports_pose_prior_image_backfill():
+            backfilled_count = self.backfill_pose_priors_from_exif()
+            after_backfill = self.count_pose_priors()
+        else:
+            backfilled_count = 0
+            after_backfill = before_backfill
+
+        self.pose_priors_written_count = after_backfill
+        self.gps_prior_coverage = round(after_backfill / self.gps_image_count, 4)
+        if backfilled_count > 0 and before_backfill > 0:
+            self.pose_priors_source = "feature_extractor_plus_backfill"
+        elif backfilled_count > 0:
+            self.pose_priors_source = "backfilled_from_exif"
+        elif before_backfill > 0:
+            self.pose_priors_source = "feature_extractor"
+        elif after_backfill == 0 and not self.supports_pose_prior_image_backfill():
+            self.pose_priors_source = "unsupported_pose_prior_schema"
+        else:
+            self.pose_priors_source = "missing"
+
+        logger.info(
+            "COLMAP pose priors available for %s/%s GPS-tagged images (coverage %.2f%%, source=%s)",
+            self.pose_priors_written_count,
+            self.gps_image_count,
+            self.gps_prior_coverage * 100.0,
+            self.pose_priors_source,
+        )
 
     def ensure_vocab_tree(self) -> None:
         started = time.time()
         if self.vocab_tree_path.exists() and self.vocab_tree_path.stat().st_size > 0:
             logger.info("Using cached vocab tree at %s", self.vocab_tree_path)
-            self.timings["download_vocab_tree_seconds"] = 0.0
+            self.timings.setdefault("download_vocab_tree_seconds", 0.0)
             self.active_vocab_tree_path = self.vocab_tree_path
             self.vocab_tree_source = "downloaded_cached"
             return
@@ -184,7 +502,7 @@ class ColmapPipeline:
             logger.info(
                 "No external vocab tree configured; letting COLMAP auto-download a compatible FAISS tree first"
             )
-            self.timings["download_vocab_tree_seconds"] = 0.0
+            self.timings.setdefault("download_vocab_tree_seconds", 0.0)
             self.vocab_tree_source = "colmap_auto_download"
             return
         self.vocab_tree_path.parent.mkdir(parents=True, exist_ok=True)
@@ -242,6 +560,7 @@ class ColmapPipeline:
         self.active_vocab_tree_path = self.generated_vocab_tree_path
 
     def run_vocab_tree_matcher(self) -> None:
+        self.ensure_vocab_tree()
         command = [
             "colmap",
             "vocab_tree_matcher",
@@ -272,6 +591,8 @@ class ColmapPipeline:
             str(self.database_path),
             "--image_path",
             str(self.images_dir),
+            "--image_list_path",
+            str(self.image_list_path),
             "--ImageReader.single_camera",
             "1",
             "--ImageReader.camera_model",
@@ -287,32 +608,85 @@ class ColmapPipeline:
         stream_command(command, stage="feature_extractor")
         self.timings["feature_extraction_seconds"] = round(time.time() - started, 2)
 
-    def run_matching(self) -> None:
-        if self.gps_image_count > 0:
-            started = time.time()
-            stream_command(
-                [
-                    "colmap",
-                    "spatial_matcher",
-                    "--database_path",
-                    str(self.database_path),
-                    "--FeatureMatching.use_gpu",
-                    "1" if self.use_gpu else "0",
-                    "--FeatureMatching.guided_matching",
-                    "1",
-                    "--SpatialMatching.ignore_z",
-                    "0",
-                    "--SpatialMatching.max_num_neighbors",
-                    str(self.spatial_neighbors),
-                    "--SpatialMatching.max_distance",
-                    str(self.spatial_distance_m),
-                ],
-                stage="spatial_matcher",
-            )
-            self.timings["spatial_matching_seconds"] = round(time.time() - started, 2)
-            self.matchers_run.append("spatial_matcher")
+    def should_attempt_gps_first(self) -> bool:
+        if not self.enable_spatial_matcher:
+            self.gps_first_skipped_reason = "spatial_matcher_disabled"
+            return False
+        if not self.force_gps_first:
+            self.gps_first_skipped_reason = "gps_first_disabled"
+            return False
+        if self.gps_image_count == 0:
+            self.gps_first_skipped_reason = "no_gps_exif"
+            return False
+        if self.gps_prior_coverage < self.gps_min_prior_coverage:
+            self.gps_first_skipped_reason = "insufficient_pose_prior_coverage"
+            return False
+        self.gps_first_skipped_reason = "eligible"
+        return True
 
+    def run_spatial_matcher(self) -> None:
         started = time.time()
+        pairs_before = self.count_verified_pairs()
+        stream_command(
+            [
+                "colmap",
+                "spatial_matcher",
+                "--database_path",
+                str(self.database_path),
+                "--FeatureMatching.use_gpu",
+                "1" if self.use_gpu else "0",
+                "--FeatureMatching.guided_matching",
+                "1",
+                "--SpatialMatching.ignore_z",
+                "0",
+                "--SpatialMatching.max_num_neighbors",
+                str(self.spatial_neighbors),
+                "--SpatialMatching.max_distance",
+                str(self.spatial_distance_m),
+            ],
+            stage="spatial_matcher",
+        )
+        pairs_after = self.count_verified_pairs()
+        self.timings["spatial_matching_seconds"] = round(time.time() - started, 2)
+        self.matcher_pair_deltas["spatial_matcher"] = pairs_after - pairs_before
+        self.matchers_run.append("spatial_matcher")
+        self.verified_pairs_total = pairs_after
+        logger.info(
+            "Spatial matcher added %s verified image pairs",
+            self.matcher_pair_deltas["spatial_matcher"],
+        )
+
+    def run_sequential_matcher(self) -> None:
+        started = time.time()
+        pairs_before = self.count_verified_pairs()
+        stream_command(
+            [
+                "colmap",
+                "sequential_matcher",
+                "--database_path",
+                str(self.database_path),
+                "--SequentialMatching.overlap",
+                str(self.sequential_overlap),
+                "--SequentialMatching.quadratic_overlap",
+                "1",
+                "--SequentialMatching.loop_detection",
+                "0",
+            ],
+            stage="sequential_matcher",
+        )
+        pairs_after = self.count_verified_pairs()
+        self.timings["sequential_matching_seconds"] = round(time.time() - started, 2)
+        self.matcher_pair_deltas["sequential_matcher"] = pairs_after - pairs_before
+        self.matchers_run.append("sequential_matcher")
+        self.verified_pairs_total = pairs_after
+        logger.info(
+            "Sequential matcher added %s verified image pairs",
+            self.matcher_pair_deltas["sequential_matcher"],
+        )
+
+    def run_vocab_matching(self) -> None:
+        started = time.time()
+        pairs_before = self.count_verified_pairs()
         try:
             self.run_vocab_tree_matcher()
         except RuntimeError as exc:
@@ -329,11 +703,19 @@ class ColmapPipeline:
                 raise
             self.build_vocab_tree()
             self.run_vocab_tree_matcher()
+        pairs_after = self.count_verified_pairs()
         self.timings["vocab_tree_matching_seconds"] = round(time.time() - started, 2)
+        self.matcher_pair_deltas["vocab_tree_matcher"] = pairs_after - pairs_before
         self.matchers_run.append("vocab_tree_matcher")
+        self.verified_pairs_total = pairs_after
+        logger.info(
+            "Vocab tree matcher added %s verified image pairs",
+            self.matcher_pair_deltas["vocab_tree_matcher"],
+        )
 
-    def run_mapper(self) -> Path:
+    def run_mapper(self, *, stage: str, sparse_root: Path) -> ModelSummary:
         started = time.time()
+        sparse_root.mkdir(parents=True, exist_ok=True)
         stream_command(
             [
                 "colmap",
@@ -343,27 +725,23 @@ class ColmapPipeline:
                 "--image_path",
                 str(self.images_dir),
                 "--output_path",
-                str(self.sparse_root),
+                str(sparse_root),
                 "--Mapper.num_threads",
                 str(self.mapper_threads),
                 "--Mapper.ba_refine_principal_point",
                 "0",
             ],
-            stage="mapper",
+            stage=stage,
         )
-        self.timings["mapper_seconds"] = round(time.time() - started, 2)
+        self.timings[f"{stage}_seconds"] = round(time.time() - started, 2)
 
-        candidate_dirs = [
-            path for path in sorted(self.sparse_root.iterdir()) if path.is_dir()
-        ]
+        candidate_dirs = [path for path in sorted(sparse_root.iterdir()) if path.is_dir()]
         if not candidate_dirs:
-            raise RuntimeError("COLMAP mapper did not produce any sparse models")
+            raise RuntimeError(f"{stage} did not produce any sparse models")
 
-        best_dir: Path | None = None
-        best_text_dir: Path | None = None
-        best_registered = -1
+        best_model: ModelSummary | None = None
         for candidate_dir in candidate_dirs:
-            text_dir = self.work_dir / "text_models" / candidate_dir.name
+            text_dir = self.work_dir / "text_models" / stage / candidate_dir.name
             text_dir.mkdir(parents=True, exist_ok=True)
             stream_command(
                 [
@@ -376,20 +754,154 @@ class ColmapPipeline:
                     "--output_type",
                     "TXT",
                 ],
-                stage=f"model_converter_{candidate_dir.name}",
+                stage=f"{stage}_model_converter_{candidate_dir.name}",
             )
-            registered = count_registered_images(text_dir / "images.txt")
-            logger.info("Model %s registered %s images", candidate_dir.name, registered)
-            if registered > best_registered:
-                best_registered = registered
-                best_dir = candidate_dir
-                best_text_dir = text_dir
-        if best_dir is None or best_text_dir is None:
-            raise RuntimeError("Unable to choose a sparse model for export")
-        logger.info("Selected sparse model %s with %s registered images", best_dir.name, best_registered)
-        return best_text_dir
+            model = ModelSummary(
+                stage=stage,
+                text_dir=text_dir,
+                cameras_registered=count_text_rows(text_dir / "cameras.txt"),
+                images_registered=count_registered_images(text_dir / "images.txt"),
+                points_3d=count_text_rows(text_dir / "points3D.txt"),
+            )
+            logger.info(
+                "%s model %s registered %s images and %s points",
+                stage,
+                candidate_dir.name,
+                model.images_registered,
+                model.points_3d,
+            )
+            if best_model is None or model_sort_key(model) > model_sort_key(best_model):
+                best_model = model
+        if best_model is None:
+            raise RuntimeError(f"Unable to choose a sparse model for {stage}")
+        self.model_summaries.append(
+            {
+                "stage": best_model.stage,
+                "cameras_registered": best_model.cameras_registered,
+                "images_registered": best_model.images_registered,
+                "points_3d": best_model.points_3d,
+            }
+        )
+        return best_model
 
-    def export_output(self, best_text_dir: Path) -> None:
+    def run_vocab_only_path(self) -> ModelSummary:
+        self.run_vocab_matching()
+        self.final_matcher_mode = "vocab_only"
+        return self.run_mapper(stage="mapper_vocab_only", sparse_root=self.work_dir / "sparse_vocab_only")
+
+    def run_spatial_sequential_plus_vocab_path(self) -> ModelSummary:
+        self.run_spatial_matcher()
+        if self.enable_sequential_matcher:
+            self.run_sequential_matcher()
+        self.run_vocab_matching()
+        self.final_matcher_mode = (
+            "spatial_sequential_plus_vocab"
+            if self.enable_sequential_matcher
+            else "spatial_plus_vocab"
+        )
+        return self.run_mapper(
+            stage=(
+                "mapper_spatial_sequential_plus_vocab"
+                if self.enable_sequential_matcher
+                else "mapper_spatial_plus_vocab"
+            ),
+            sparse_root=(
+                self.work_dir / "sparse_spatial_sequential_plus_vocab"
+                if self.enable_sequential_matcher
+                else self.work_dir / "sparse_spatial_plus_vocab"
+            ),
+        )
+
+    def run_matching_and_mapping(self) -> ModelSummary:
+        if not self.should_attempt_gps_first():
+            if (
+                self.enable_spatial_matcher
+                and self.gps_image_count > 0
+                and self.gps_prior_coverage >= self.gps_min_prior_coverage
+            ):
+                return self.run_spatial_sequential_plus_vocab_path()
+            return self.run_vocab_only_path()
+
+        self.gps_first_attempted = True
+        spatial_model: ModelSummary | None = None
+        try:
+            self.run_spatial_matcher()
+            if self.enable_sequential_matcher:
+                self.run_sequential_matcher()
+            spatial_model = self.run_mapper(
+                stage=(
+                    "mapper_spatial_sequential_only"
+                    if self.enable_sequential_matcher
+                    else "mapper_spatial_only"
+                ),
+                sparse_root=(
+                    self.work_dir / "sparse_spatial_sequential_only"
+                    if self.enable_sequential_matcher
+                    else self.work_dir / "sparse_spatial_only"
+                ),
+            )
+        except RuntimeError as exc:
+            self.fallback_triggered = True
+            self.fallback_reason = "mapper_failed"
+            logger.warning("GPS-first first-pass mapper failed, falling back to vocab tree: %s", exc)
+
+        if spatial_model is not None:
+            registered_ratio = (
+                spatial_model.images_registered / self.dataset_image_count
+                if self.dataset_image_count
+                else 0.0
+            )
+            logger.info(
+                "First-pass mapper registered %s/%s extracted images (%.2f%%)",
+                spatial_model.images_registered,
+                self.dataset_image_count,
+                registered_ratio * 100.0,
+            )
+            if registered_ratio >= self.gps_min_registered_ratio:
+                self.final_matcher_mode = (
+                    "spatial_sequential_only"
+                    if self.enable_sequential_matcher
+                    else "spatial_only"
+                )
+                return spatial_model
+            self.fallback_triggered = True
+            self.fallback_reason = "below_registered_ratio_threshold"
+            logger.info(
+                "First-pass mapper registered %s/%s images (%.2f%%), below %.2f%% threshold; adding vocab-tree recovery",
+                spatial_model.images_registered,
+                self.dataset_image_count,
+                registered_ratio * 100.0,
+                self.gps_min_registered_ratio * 100.0,
+            )
+
+        self.run_vocab_matching()
+        fallback_model = self.run_mapper(
+            stage=(
+                "mapper_spatial_sequential_plus_vocab"
+                if self.enable_sequential_matcher
+                else "mapper_spatial_plus_vocab"
+            ),
+            sparse_root=(
+                self.work_dir / "sparse_spatial_sequential_plus_vocab"
+                if self.enable_sequential_matcher
+                else self.work_dir / "sparse_spatial_plus_vocab"
+            ),
+        )
+        if spatial_model is not None and model_sort_key(spatial_model) > model_sort_key(fallback_model):
+            self.final_matcher_mode = (
+                "spatial_sequential_only_better_than_fallback"
+                if self.enable_sequential_matcher
+                else "spatial_only_better_than_fallback"
+            )
+            return spatial_model
+        self.final_matcher_mode = (
+            "spatial_sequential_plus_vocab"
+            if self.enable_sequential_matcher
+            else "spatial_plus_vocab"
+        )
+        return fallback_model
+
+    def export_output(self, best_model: ModelSummary) -> None:
         sparse_output = self.output_dir / "sparse" / "0"
         images_output = self.output_dir / "images"
 
@@ -399,24 +911,42 @@ class ColmapPipeline:
             shutil.rmtree(images_output)
 
         sparse_output.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(best_text_dir, sparse_output)
+        shutil.copytree(best_model.text_dir, sparse_output)
         shutil.copytree(self.images_dir, images_output)
         shutil.copy2(self.database_path, self.output_dir / "database.db")
 
-        cameras = count_text_rows(sparse_output / "cameras.txt")
-        images = count_registered_images(sparse_output / "images.txt")
-        points = count_text_rows(sparse_output / "points3D.txt")
         metadata = {
-            "pipeline": "colmap_gpu_vocab_tree",
+            "pipeline": "colmap_gpu_adaptive_matching",
             "processing_time_seconds": round(time.time() - self.start_time, 2),
             "timings": self.timings,
-            "cameras_registered": cameras,
-            "images_registered": images,
-            "points_3d": points,
-            "quality_check_passed": points >= 1000 and images > 0 and cameras > 0,
+            "dataset_image_count": self.dataset_image_count,
+            "cameras_registered": best_model.cameras_registered,
+            "images_registered": best_model.images_registered,
+            "points_3d": best_model.points_3d,
+            "quality_check_passed": (
+                best_model.points_3d >= 1000
+                and best_model.images_registered > 0
+                and best_model.cameras_registered > 0
+            ),
             "gpu_enabled": self.use_gpu,
             "gps_priors_detected": self.gps_image_count,
+            "gps_exif_count": self.gps_image_count,
+            "pose_priors_written_count": self.pose_priors_written_count,
+            "pose_priors_source": self.pose_priors_source,
+            "gps_prior_coverage": self.gps_prior_coverage,
             "matchers_run": self.matchers_run,
+            "matcher_pair_deltas": self.matcher_pair_deltas,
+            "verified_pairs_total": self.verified_pairs_total,
+            "spatial_matcher_enabled": self.enable_spatial_matcher,
+            "sequential_matcher_enabled": self.enable_sequential_matcher,
+            "sequential_pair_delta": self.matcher_pair_deltas.get("sequential_matcher", 0),
+            "match_profile": self.match_profile,
+            "gps_first_attempted": self.gps_first_attempted,
+            "gps_first_skipped_reason": self.gps_first_skipped_reason,
+            "fallback_triggered": self.fallback_triggered,
+            "fallback_reason": self.fallback_reason,
+            "final_matcher_mode": self.final_matcher_mode,
+            "model_summaries": self.model_summaries,
             "vocab_tree_path": str(self.active_vocab_tree_path or self.vocab_tree_path),
             "vocab_tree_bytes": (
                 (self.active_vocab_tree_path or self.vocab_tree_path).stat().st_size
@@ -430,6 +960,7 @@ class ColmapPipeline:
             "vocab_tree_num_images": self.vocab_num_images,
             "vocab_tree_num_visual_words": self.vocab_num_visual_words,
             "vocab_tree_max_num_descriptors": self.vocab_max_num_descriptors,
+            "benchmark_subset_strategy": self.benchmark_subset_strategy,
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         }
         with open(self.output_dir / "sfm_metadata.json", "w", encoding="utf-8") as handle:
@@ -438,7 +969,9 @@ class ColmapPipeline:
         if not metadata["quality_check_passed"]:
             raise RuntimeError(
                 f"Exported sparse model failed quality gate: "
-                f"cameras={cameras}, images={images}, points={points}"
+                f"cameras={best_model.cameras_registered}, "
+                f"images={best_model.images_registered}, "
+                f"points={best_model.points_3d}"
             )
 
 

--- a/tests/unit/test_colmap_gps_priors.py
+++ b/tests/unit/test_colmap_gps_priors.py
@@ -1,0 +1,393 @@
+import importlib.util
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "infrastructure" / "containers" / "sfm" / "run_colmap_sfm.py"
+SPEC = importlib.util.spec_from_file_location("run_colmap_sfm_test_module", MODULE_PATH)
+run_colmap_sfm = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = run_colmap_sfm
+SPEC.loader.exec_module(run_colmap_sfm)
+
+
+class ColmapGpsPriorTests(unittest.TestCase):
+    def test_match_profile_picks_profile_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            os.environ,
+            {
+                "COLMAP_MATCH_PROFILE": "P2",
+                "COLMAP_ENABLE_SEQUENTIAL_MATCHER": "1",
+            },
+            clear=False,
+        ):
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+
+            self.assertEqual(pipeline.match_profile, "P2")
+            self.assertEqual(pipeline.spatial_neighbors, 14)
+            self.assertEqual(pipeline.spatial_distance_m, 140.0)
+            self.assertEqual(pipeline.sequential_overlap, 8)
+
+    def test_match_profile_marks_custom_when_overridden(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            os.environ,
+            {
+                "COLMAP_MATCH_PROFILE": "P1",
+                "COLMAP_SPATIAL_MAX_NEIGHBORS": "16",
+                "COLMAP_ENABLE_SEQUENTIAL_MATCHER": "0",
+            },
+            clear=False,
+        ):
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+
+            self.assertEqual(pipeline.match_profile, "custom")
+            self.assertEqual(pipeline.spatial_neighbors, 16)
+            self.assertFalse(pipeline.enable_sequential_matcher)
+
+    def test_get_pose_prior_image_names_uses_schema_tolerant_join(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            pipeline.database_path = root / "database.db"
+
+            with sqlite3.connect(pipeline.database_path) as connection:
+                connection.execute("CREATE TABLE images(image_id INTEGER PRIMARY KEY, name TEXT)")
+                connection.execute(
+                    """
+                    CREATE TABLE pose_priors(
+                        image_id INTEGER PRIMARY KEY,
+                        position BLOB,
+                        coordinate_system INTEGER,
+                        position_covariance BLOB
+                    )
+                    """
+                )
+                connection.execute("INSERT INTO images(image_id, name) VALUES (1, 'a.jpg'), (2, 'b.jpg')")
+                connection.execute(
+                    """
+                    INSERT INTO pose_priors(image_id, position, coordinate_system, position_covariance)
+                    VALUES (2, X'00', 0, X'00')
+                    """
+                )
+                connection.commit()
+
+            self.assertEqual(pipeline.get_pose_prior_image_names(), {"b.jpg"})
+
+    def test_validate_pose_priors_skips_backfill_for_newer_schema_variant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            pipeline.database_path = root / "database.db"
+            pipeline.gps_image_count = 2
+
+            with sqlite3.connect(pipeline.database_path) as connection:
+                connection.execute("CREATE TABLE images(image_id INTEGER PRIMARY KEY, name TEXT)")
+                connection.execute(
+                    """
+                    CREATE TABLE pose_priors(
+                        pose_prior_id INTEGER PRIMARY KEY,
+                        position BLOB,
+                        coordinate_system INTEGER,
+                        position_covariance BLOB,
+                        gravity BLOB,
+                        corr_sensor_id INTEGER,
+                        corr_sensor_type INTEGER
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO pose_priors(
+                        pose_prior_id,
+                        position,
+                        coordinate_system,
+                        position_covariance,
+                        gravity,
+                        corr_sensor_id,
+                        corr_sensor_type
+                    ) VALUES
+                        (1, X'00', 0, X'00', NULL, NULL, NULL),
+                        (2, X'00', 0, X'00', NULL, NULL, NULL)
+                    """
+                )
+                connection.commit()
+
+            pipeline.validate_or_backfill_pose_priors()
+
+            self.assertEqual(pipeline.pose_priors_written_count, 2)
+            self.assertEqual(pipeline.gps_prior_coverage, 1.0)
+            self.assertEqual(pipeline.pose_priors_source, "feature_extractor")
+
+    def test_backfill_pose_priors_restores_missing_wgs84_priors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_dir = root / "input"
+            output_dir = root / "output"
+            images_dir = root / "images"
+            input_dir.mkdir()
+            output_dir.mkdir()
+            images_dir.mkdir()
+
+            for name, latitude in [("a.jpg", 40.1001), ("b.jpg", 40.2002)]:
+                image_path = images_dir / name
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-f",
+                        "lavfi",
+                        "-i",
+                        "testsrc=size=512x512:rate=1",
+                        "-frames:v",
+                        "1",
+                        str(image_path),
+                        "-y",
+                        "-loglevel",
+                        "error",
+                    ],
+                    check=True,
+                )
+                subprocess.run(
+                    [
+                        "exiftool",
+                        "-overwrite_original",
+                        f"-GPSLatitude={latitude}",
+                        "-GPSLongitude=-105.1234",
+                        "-GPSAltitude=1500.5",
+                        str(image_path),
+                    ],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                )
+
+            pipeline = run_colmap_sfm.ColmapPipeline(input_dir, output_dir)
+            pipeline.images_dir = images_dir
+            pipeline.database_path = root / "database.db"
+            pipeline.exif_records = pipeline.load_exif_records()
+            pipeline.gps_image_count = len(pipeline.exif_records)
+
+            subprocess.run(
+                [
+                    "colmap",
+                    "feature_extractor",
+                    "--database_path",
+                    str(pipeline.database_path),
+                    "--image_path",
+                    str(images_dir),
+                    "--ImageReader.single_camera",
+                    "1",
+                    "--ImageReader.camera_model",
+                    "SIMPLE_RADIAL",
+                    "--SiftExtraction.use_gpu",
+                    "0",
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            with sqlite3.connect(pipeline.database_path) as connection:
+                connection.execute("DELETE FROM pose_priors")
+                connection.commit()
+
+            pipeline.validate_or_backfill_pose_priors()
+
+            self.assertEqual(pipeline.pose_priors_source, "backfilled_from_exif")
+            self.assertEqual(pipeline.pose_priors_written_count, 2)
+            self.assertEqual(pipeline.gps_prior_coverage, 1.0)
+
+            with sqlite3.connect(pipeline.database_path) as connection:
+                rows = connection.execute(
+                    "SELECT coordinate_system, length(position), length(position_covariance) "
+                    "FROM pose_priors ORDER BY image_id"
+                ).fetchall()
+
+            self.assertEqual(rows, [(0, 24, 72), (0, 24, 72)])
+
+    def test_should_attempt_gps_first_requires_prior_coverage_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            pipeline.gps_image_count = 10
+            pipeline.gps_prior_coverage = 0.94
+            self.assertFalse(pipeline.should_attempt_gps_first())
+            self.assertEqual(pipeline.gps_first_skipped_reason, "insufficient_pose_prior_coverage")
+
+            pipeline.gps_prior_coverage = 0.95
+            self.assertTrue(pipeline.should_attempt_gps_first())
+            self.assertEqual(pipeline.gps_first_skipped_reason, "eligible")
+
+    def test_gps_first_uses_sequential_first_pass_when_registration_is_complete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            pipeline.dataset_image_count = 3
+            pipeline.gps_image_count = 3
+            pipeline.gps_prior_coverage = 1.0
+            pipeline.enable_sequential_matcher = True
+
+            calls: list[str] = []
+
+            def record_call(name: str):
+                def inner(*args, **kwargs):
+                    calls.append(name)
+                    return None
+
+                return inner
+
+            pipeline.run_spatial_matcher = record_call("spatial_matcher")
+            pipeline.run_sequential_matcher = record_call("sequential_matcher")
+            pipeline.run_vocab_matching = record_call("vocab_tree_matcher")
+            pipeline.run_mapper = mock.Mock(
+                return_value=run_colmap_sfm.ModelSummary(
+                    stage="mapper_spatial_sequential_only",
+                    text_dir=root,
+                    cameras_registered=1,
+                    images_registered=3,
+                    points_3d=2500,
+                )
+            )
+
+            best_model = pipeline.run_matching_and_mapping()
+
+            self.assertEqual(best_model.images_registered, 3)
+            self.assertEqual(calls, ["spatial_matcher", "sequential_matcher"])
+            self.assertEqual(pipeline.final_matcher_mode, "spatial_sequential_only")
+            self.assertFalse(pipeline.fallback_triggered)
+            self.assertEqual(pipeline.fallback_reason, "not_needed")
+
+    def test_gps_first_falls_back_once_when_registration_is_incomplete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            pipeline.dataset_image_count = 4
+            pipeline.gps_image_count = 4
+            pipeline.gps_prior_coverage = 1.0
+            pipeline.enable_sequential_matcher = True
+
+            calls: list[str] = []
+
+            def record_call(name: str):
+                def inner(*args, **kwargs):
+                    calls.append(name)
+                    return None
+
+                return inner
+
+            spatial_model = run_colmap_sfm.ModelSummary(
+                stage="mapper_spatial_sequential_only",
+                text_dir=root,
+                cameras_registered=1,
+                images_registered=3,
+                points_3d=3000,
+            )
+            fallback_model = run_colmap_sfm.ModelSummary(
+                stage="mapper_spatial_sequential_plus_vocab",
+                text_dir=root,
+                cameras_registered=1,
+                images_registered=4,
+                points_3d=3400,
+            )
+
+            pipeline.run_spatial_matcher = record_call("spatial_matcher")
+            pipeline.run_sequential_matcher = record_call("sequential_matcher")
+            pipeline.run_vocab_matching = record_call("vocab_tree_matcher")
+            pipeline.run_mapper = mock.Mock(side_effect=[spatial_model, fallback_model])
+
+            best_model = pipeline.run_matching_and_mapping()
+
+            self.assertEqual(best_model.images_registered, 4)
+            self.assertEqual(
+                calls,
+                ["spatial_matcher", "sequential_matcher", "vocab_tree_matcher"],
+            )
+            self.assertTrue(pipeline.fallback_triggered)
+            self.assertEqual(pipeline.fallback_reason, "below_registered_ratio_threshold")
+            self.assertEqual(pipeline.final_matcher_mode, "spatial_sequential_plus_vocab")
+
+    def test_gps_first_accepts_ratio_threshold_without_vocab_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            pipeline.dataset_image_count = 100
+            pipeline.gps_image_count = 100
+            pipeline.gps_prior_coverage = 1.0
+            pipeline.enable_sequential_matcher = True
+            pipeline.gps_min_registered_ratio = 0.98
+
+            calls: list[str] = []
+
+            def record_call(name: str):
+                def inner(*args, **kwargs):
+                    calls.append(name)
+                    return None
+
+                return inner
+
+            spatial_model = run_colmap_sfm.ModelSummary(
+                stage="mapper_spatial_sequential_only",
+                text_dir=root,
+                cameras_registered=1,
+                images_registered=98,
+                points_3d=5000,
+            )
+
+            pipeline.run_spatial_matcher = record_call("spatial_matcher")
+            pipeline.run_sequential_matcher = record_call("sequential_matcher")
+            pipeline.run_vocab_matching = record_call("vocab_tree_matcher")
+            pipeline.run_mapper = mock.Mock(return_value=spatial_model)
+
+            best_model = pipeline.run_matching_and_mapping()
+
+            self.assertEqual(best_model.images_registered, 98)
+            self.assertEqual(calls, ["spatial_matcher", "sequential_matcher"])
+            self.assertFalse(pipeline.fallback_triggered)
+            self.assertEqual(pipeline.fallback_reason, "not_needed")
+            self.assertEqual(pipeline.final_matcher_mode, "spatial_sequential_only")
+
+    def test_run_mapper_does_not_pass_image_list_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+            sparse_root = root / "sparse_vocab_only"
+            (sparse_root / "0").mkdir(parents=True, exist_ok=True)
+
+            with mock.patch.object(run_colmap_sfm, "stream_command") as stream_command_mock, mock.patch.object(
+                run_colmap_sfm, "count_text_rows", return_value=1
+            ), mock.patch.object(run_colmap_sfm, "count_registered_images", return_value=3):
+                model = pipeline.run_mapper(stage="mapper_vocab_only", sparse_root=sparse_root)
+
+            mapper_args = stream_command_mock.call_args_list[0].kwargs["stage"]
+            self.assertEqual(mapper_args, "mapper_vocab_only")
+            mapper_command = stream_command_mock.call_args_list[0].args[0]
+            self.assertNotIn("--image_list_path", mapper_command)
+            self.assertEqual(model.images_registered, 3)
+
+    def test_run_sequential_matcher_avoids_runtime_specific_matching_flags(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pipeline = run_colmap_sfm.ColmapPipeline(root / "input", root / "output")
+
+            with mock.patch.object(run_colmap_sfm, "stream_command") as stream_command_mock, mock.patch.object(
+                pipeline, "count_verified_pairs", side_effect=[10, 16]
+            ):
+                pipeline.run_sequential_matcher()
+
+            command = stream_command_mock.call_args.args[0]
+            self.assertIn("sequential_matcher", command)
+            self.assertNotIn("--SiftMatching.use_gpu", command)
+            self.assertNotIn("--SiftMatching.guided_matching", command)
+            self.assertEqual(pipeline.matcher_pair_deltas["sequential_matcher"], 6)
+            self.assertIn("sequential_matcher", pipeline.matchers_run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
This promotes the proven GPS-first SfM fallback update into a clean branch from `development`.

Included changes:
- promote the exact `run_colmap_sfm.py` fallback behavior used by the successful Horsetail SfM input lineage
- add the matching unit coverage in `tests/unit/test_colmap_gps_priors.py`
- keep the scope limited to the SfM container logic and tests only

## Proven lineage
- exact proven source lineage: `agent-94836271-sfm-gps-priors@57e8c822`
- validated output using this stack: Horsetail original SfM dataset used for the successful Brass-matched rerender

## Why
This is the narrowest safe promotion path for the Horsetail-proven GPS-prior fallback logic. It updates `development` to the exact behavior we already relied on in production-quality runs without pulling unrelated branch drift.

## Validation
Local:
- `/tmp/codex-spaceport-venv/bin/python -m pytest tests/unit/test_colmap_gps_priors.py`

Remote:
- `CDK Deploy`: success
- `Trigger ML Container Build`: success
- `deploy-cloudflare-pages.yml` did not trigger because this branch has no web-path changes
