### PR TITLE
feat: add static property photo uploads

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -95,6 +95,7 @@ jobs:
       run: |
         set -euo pipefail
         python3 ../../scripts/resolve_preview_context.py --branch "${GITHUB_REF_NAME}" --format shell > /tmp/deploy-context.env
+        python3 ../../scripts/resolve_auth_deploy_mode.py --branch "${GITHUB_REF_NAME}" --repo-root ../.. --format shell >> /tmp/deploy-context.env
         cat /tmp/deploy-context.env
         while IFS='=' read -r key value; do
           echo "${key}=${value}" >> "$GITHUB_ENV"
@@ -282,6 +283,12 @@ jobs:
         fi
 
         if [ "${DEPLOYMENT_CLASS}" = "branch-preview" ]; then
+          if [ "${DEPLOY_AUTH_STACK_EFFECTIVE:-false}" = "true" ]; then
+            STACK_DEPLOY_REQUIRED="true"
+            AUTH_STACK_CHANGED="true"
+            echo "Preview auth opt-in marker is present - forcing shared auth stack deploy"
+          fi
+
           CURRENT_EXPLORE_API_URL=$(aws cloudformation describe-stacks \
             --stack-name "${AUTH_STACK_NAME}" \
             --query "Stacks[0].Outputs[?OutputKey=='ExplorePublicApiUrl'].OutputValue" \

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -276,7 +276,7 @@ jobs:
           echo "Lambda functions changed - will deploy branch-specific Lambda versions"
         fi
 
-        if printf '%s\n' "${CHANGED_FILES}" | grep -Eq '^(infrastructure/spaceport_cdk/app\.py|infrastructure/spaceport_cdk/spaceport_cdk/deployment_context\.py|infrastructure/spaceport_cdk/spaceport_cdk/auth_stack\.py|infrastructure/spaceport_cdk/lambda/explore_public/|infrastructure/spaceport_cdk/lambda/model_delivery_admin/|infrastructure/cloudflare/spaces-thumbnail/)'; then
+        if printf '%s\n' "${CHANGED_FILES}" | grep -Eq '^(infrastructure/spaceport_cdk/app\.py|infrastructure/spaceport_cdk/spaceport_cdk/deployment_context\.py|infrastructure/spaceport_cdk/spaceport_cdk/auth_stack\.py|infrastructure/spaceport_cdk/lambda/explore_public/|infrastructure/spaceport_cdk/lambda/model_delivery_admin/|infrastructure/spaceport_cdk/lambda/projects/|infrastructure/cloudflare/spaces-thumbnail/)'; then
           AUTH_STACK_CHANGED="true"
           echo "Auth-backed explore files changed - will deploy shared auth stack for this branch"
         fi

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -329,11 +329,13 @@ jobs:
         R2_SECRET_ACCESS_KEY_STAGING: ${{ secrets.R2_SECRET_ACCESS_KEY_STAGING }}
         R2_BUCKET_NAME_STAGING: ${{ secrets.R2_BUCKET_NAME_STAGING }}
         R2_REGION_STAGING: ${{ secrets.R2_REGION_STAGING }}
+        R2_PUBLIC_BASE_URL_STAGING: ${{ secrets.R2_PUBLIC_BASE_URL_STAGING }}
         R2_ENDPOINT_PROD: ${{ secrets.R2_ENDPOINT_PROD }}
         R2_ACCESS_KEY_ID_PROD: ${{ secrets.R2_ACCESS_KEY_ID_PROD }}
         R2_SECRET_ACCESS_KEY_PROD: ${{ secrets.R2_SECRET_ACCESS_KEY_PROD }}
         R2_BUCKET_NAME_PROD: ${{ secrets.R2_BUCKET_NAME_PROD }}
         R2_REGION_PROD: ${{ secrets.R2_REGION_PROD }}
+        R2_PUBLIC_BASE_URL_PROD: ${{ secrets.R2_PUBLIC_BASE_URL_PROD }}
         SPACES_THUMBNAIL_URL: ${{ secrets.SPACES_THUMBNAIL_URL }}
         SPACES_THUMBNAIL_TOKEN: ${{ secrets.SPACES_THUMBNAIL_TOKEN }}
         # Referral system configuration - using CDK defaults (Option A)

--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,5 @@
 reason: static photo upload feature deployment wiring
-last_step: found projects Lambda changes were not classified as shared auth/projects stack changes and patched the deploy-scope rule
-next_unblocked_step: commit, push, monitor shared auth/projects stack deployment, and verify runtime endpoint behavior
+last_step: deploy-scope rule is patched; adding a projects Lambda change so the corrected rule redeploys the shared projects stack
+next_unblocked_step: commit, push, monitor shared projects stack deployment, and verify runtime endpoint behavior
 owner_action_needed: none
-updated: 2026-05-04T17:49:00Z
+updated: 2026-05-04T17:54:00Z

--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,5 @@
-reason: static photo upload feature deployment wiring
-last_step: deploy-scope rule is patched; adding a projects Lambda change so the corrected rule redeploys the shared projects stack
-next_unblocked_step: commit, push, monitor shared projects stack deployment, and verify runtime endpoint behavior
+reason: static photo upload switcher visual polish
+last_step: replaced the blue outlined upload-mode buttons with the requested filled pill switcher and verified desktop/mobile fit
+next_unblocked_step: commit, push, monitor Pages/CDK workflows, and verify preview UI
 owner_action_needed: none
-updated: 2026-05-04T17:54:00Z
+updated: 2026-05-04T18:08:00Z

--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,5 @@
 reason: static photo upload feature deployment wiring
-last_step: deployed the spaces media worker route and added a Lambda-side config clarification to force branch stack redeploy
-next_unblocked_step: commit, push, monitor CDK stack deployment, and verify runtime endpoint behavior
+last_step: found projects Lambda changes were not classified as shared auth/projects stack changes and patched the deploy-scope rule
+next_unblocked_step: commit, push, monitor shared auth/projects stack deployment, and verify runtime endpoint behavior
 owner_action_needed: none
-updated: 2026-05-04T17:43:00Z
+updated: 2026-05-04T17:49:00Z

--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,5 @@
-reason: executing phase 2 branch sync by merging origin/development into codex/agent-72759001-sync-development-into-ml and validating the integrated branch
-last_step: completed the phase 2 baseline checks, merged origin/development into the phase 2 branch, and started resolving the expected workflow and web content conflicts
-next_unblocked_step: finish conflict resolution, audit the auto-merged infra files for branch-aware naming and R2/payment settings, push the branch, and monitor Pages/CDK/container checks to green
+reason: static photo upload feature deployment wiring
+last_step: added R2_PUBLIC_BASE_URL deployment wiring, configured repo secrets, and verified local unit/compile checks
+next_unblocked_step: commit, push, deploy workers, monitor Pages/CDK workflows, and verify preview/runtime endpoints
 owner_action_needed: none
-updated: 2026-03-06T02:16:00Z
+updated: 2026-05-04T17:37:00Z

--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,5 @@
 reason: static photo upload feature deployment wiring
-last_step: added R2_PUBLIC_BASE_URL deployment wiring, configured repo secrets, and verified local unit/compile checks
-next_unblocked_step: commit, push, deploy workers, monitor Pages/CDK workflows, and verify preview/runtime endpoints
+last_step: deployed the spaces media worker route and added a Lambda-side config clarification to force branch stack redeploy
+next_unblocked_step: commit, push, monitor CDK stack deployment, and verify runtime endpoint behavior
 owner_action_needed: none
-updated: 2026-05-04T17:37:00Z
+updated: 2026-05-04T17:43:00Z

--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,15 @@
-reason: static photo upload switcher visual polish
-last_step: replaced the blue outlined upload-mode buttons with the requested filled pill switcher and verified desktop/mobile fit
-next_unblocked_step: commit, push, monitor Pages/CDK workflows, and verify preview UI
+status: completed
+last_step: found Jayden Flake's 2026-04-30 forwarded Gmail source in local Mail, downloaded the nine Dropbox source folders, uploaded 272 JPEG static photos into the three hello@spcprt.com project photo libraries, and verified every public URL
+proof:
+  source_email: "Jayden Flake, 2026-04-30, subject: Fwd: Bozeman Property Models; forwarded from Alix Carpenter <alix@suplatinum.com>"
+  manifest: /tmp/spaceport-static-photo-source/upload-manifest.json
+  verification: /tmp/spaceport-static-photo-source/verification.json
+  counts:
+    Incognito: 87 files, 4 folders, projectId 78659e97-7978-43f6-88b8-577e45f182de
+    Brass Lantern: 86 files, 2 folders, projectId 9988ace7-373e-4364-ad1c-74662068cd74
+    Lightfell: 99 files, 3 folders, projectId 97d978ad-6e40-4f4b-97cd-ed7e5d921da5
+  public_reachability: 272 checked, 272 passed, 0 failed
+  sample_sha256: 9 folder samples downloaded from public URLs and matched local source bytes
+next_unblocked_step: use the photoLibrary.files publicUrl values on the future property viewers or tap-dot configs
 owner_action_needed: none
-updated: 2026-05-04T18:08:00Z
+updated: 2026-05-05T22:40:00Z

--- a/infrastructure/cloudflare/spaces-viewer/README.md
+++ b/infrastructure/cloudflare/spaces-viewer/README.md
@@ -7,6 +7,7 @@ Hosts per-model HTML viewer files from Cloudflare R2 at branded URLs.
 - Store files in R2 under `models/{slug}/index.html`.
 - Serve viewer pages at `GET /spaces/{slug}`.
 - Serve viewer assets at `GET /spaces/{slug}/{asset}` (e.g., `thumb.jpg`).
+- Serve raw public media files at `GET /spaces/media/{r2-key}` for project photo libraries.
 
 ## Configuration
 - **R2 bucket**: `spaces-viewers` (binding `SPACES_BUCKET`)

--- a/infrastructure/cloudflare/spaces-viewer/src/index.ts
+++ b/infrastructure/cloudflare/spaces-viewer/src/index.ts
@@ -1,6 +1,7 @@
 const DEFAULT_CACHE_CONTROL = 'public, max-age=300';
 const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
 const DISALLOWED_PATH_SEGMENTS = new Set(['..', '.']);
+const MEDIA_PATH_PREFIX = '/media';
 
 interface Env {
   SPACES_BUCKET: R2Bucket;
@@ -322,6 +323,39 @@ function resolveViewerKey(pathname: string): { slug: string; key: string } | nul
   return { slug, key };
 }
 
+function resolveMediaKey(pathname: string): string | null {
+  if (pathname !== MEDIA_PATH_PREFIX && !pathname.startsWith(`${MEDIA_PATH_PREFIX}/`)) {
+    return null;
+  }
+  const key = pathname.slice(MEDIA_PATH_PREFIX.length).replace(/^\/+/, '');
+  const parts = key.split('/').filter(Boolean);
+  if (!parts.length) return null;
+  if (parts.some((segment) => DISALLOWED_PATH_SEGMENTS.has(segment) || segment.startsWith('.'))) {
+    return null;
+  }
+  return parts.join('/');
+}
+
+async function handleMedia(request: Request, env: Env, pathname: string): Promise<Response> {
+  const key = resolveMediaKey(pathname);
+  if (!key) {
+    return new Response('Not found', { status: 404, headers: corsHeaders });
+  }
+
+  const object = await env.SPACES_BUCKET.get(key);
+  if (!object) {
+    return new Response('Not found', { status: 404, headers: corsHeaders });
+  }
+
+  const headers = new Headers(corsHeaders);
+  object.writeHttpMetadata(headers);
+  headers.set('Cache-Control', object.httpMetadata?.cacheControl || DEFAULT_CACHE_CONTROL);
+  headers.set('Content-Type', object.httpMetadata?.contentType || 'application/octet-stream');
+  headers.set('ETag', object.httpEtag);
+
+  return new Response(request.method === 'HEAD' ? null : object.body, { status: 200, headers });
+}
+
 async function handleViewer(request: Request, env: Env, pathname: string): Promise<Response> {
   const resolved = resolveViewerKey(pathname);
   const slug = resolved?.slug;
@@ -383,6 +417,9 @@ export default {
     }
 
     if (request.method === 'GET' || request.method === 'HEAD') {
+      if (pathname === MEDIA_PATH_PREFIX || pathname.startsWith(`${MEDIA_PATH_PREFIX}/`)) {
+        return handleMedia(request, env, pathname);
+      }
       return handleViewer(request, env, pathname);
     }
 

--- a/infrastructure/spaceport_cdk/lambda/projects/lambda_function.py
+++ b/infrastructure/spaceport_cdk/lambda/projects/lambda_function.py
@@ -148,7 +148,7 @@ def _build_static_photo_key(user_sub: str, project_id: str, relative_path: str) 
 
 def _public_url_for_key(object_key: str) -> str:
     if not R2_PUBLIC_BASE_URL:
-        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads. Set the deploy secret for this environment.')
+        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads. Set R2_PUBLIC_BASE_URL_STAGING or R2_PUBLIC_BASE_URL_PROD.')
     return f"{R2_PUBLIC_BASE_URL}/{object_key}"
 
 
@@ -188,7 +188,7 @@ def _create_static_photo_upload_urls(user_sub: str, project_id: str, files: Any)
     if not client:
         raise RuntimeError('R2 is not configured for static photo uploads.')
     if not R2_PUBLIC_BASE_URL:
-        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads. Set the deploy secret for this environment.')
+        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads. Set R2_PUBLIC_BASE_URL_STAGING or R2_PUBLIC_BASE_URL_PROD.')
 
     validated_files = _validate_static_photo_request(files)
     results = []

--- a/infrastructure/spaceport_cdk/lambda/projects/lambda_function.py
+++ b/infrastructure/spaceport_cdk/lambda/projects/lambda_function.py
@@ -5,7 +5,7 @@ import time
 import urllib.request
 from decimal import Decimal
 from typing import Any, Dict, Optional
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
 import boto3
 from botocore.config import Config
@@ -53,6 +53,11 @@ R2_ACCESS_KEY_ID = os.environ.get('R2_ACCESS_KEY_ID')
 R2_SECRET_ACCESS_KEY = os.environ.get('R2_SECRET_ACCESS_KEY')
 R2_BUCKET_NAME = os.environ.get('R2_BUCKET_NAME', 'spaces-viewers')
 R2_REGION = os.environ.get('R2_REGION', 'auto')
+R2_PUBLIC_BASE_URL = (os.environ.get('R2_PUBLIC_BASE_URL') or '').rstrip('/')
+
+MAX_STATIC_PHOTO_FILES = 500
+MAX_STATIC_PHOTO_SIZE_BYTES = 50 * 1024 * 1024
+STATIC_PHOTO_UPLOAD_EXPIRES_SECONDS = 15 * 60
 
 
 def _cors_headers() -> Dict[str, str]:
@@ -108,6 +113,113 @@ def _get_r2_client() -> Optional[Any]:
         aws_secret_access_key=R2_SECRET_ACCESS_KEY,
         config=Config(signature_version='s3v4'),
     )
+
+
+def _safe_key_segment(value: str) -> str:
+    cleaned = ''.join(ch for ch in str(value or '').strip() if ch not in '\x00\r\n')
+    if cleaned in ('', '.', '..'):
+        cleaned = 'untitled'
+    return quote(cleaned, safe='._-()')
+
+
+def _sanitize_relative_path(relative_path: str) -> str:
+    normalized = str(relative_path or '').replace('\\', '/').strip('/')
+    parts = []
+    for raw_part in normalized.split('/'):
+        part = raw_part.strip()
+        if not part or part in ('.', '..'):
+            continue
+        parts.append(_safe_key_segment(part))
+    if not parts:
+        parts.append('untitled')
+    return '/'.join(parts)
+
+
+def _build_static_photo_key(user_sub: str, project_id: str, relative_path: str) -> str:
+    return '/'.join([
+        'users',
+        _safe_key_segment(user_sub),
+        'projects',
+        _safe_key_segment(project_id),
+        'photos',
+        _sanitize_relative_path(relative_path),
+    ])
+
+
+def _public_url_for_key(object_key: str) -> str:
+    if not R2_PUBLIC_BASE_URL:
+        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads.')
+    return f"{R2_PUBLIC_BASE_URL}/{object_key}"
+
+
+def _validate_static_photo_request(files: Any) -> list[Dict[str, Any]]:
+    if not isinstance(files, list) or not files:
+        raise ValueError('files must be a non-empty list')
+    if len(files) > MAX_STATIC_PHOTO_FILES:
+        raise ValueError(f'files cannot exceed {MAX_STATIC_PHOTO_FILES} items')
+
+    validated = []
+    for index, file_info in enumerate(files):
+        if not isinstance(file_info, dict):
+            raise ValueError(f'files[{index}] must be an object')
+        name = (file_info.get('name') or '').strip()
+        relative_path = (file_info.get('relativePath') or name).strip()
+        content_type = (file_info.get('contentType') or 'application/octet-stream').strip()
+        size_bytes = int(file_info.get('sizeBytes') or 0)
+        if not name:
+            raise ValueError(f'files[{index}].name is required')
+        if not content_type.startswith('image/'):
+            raise ValueError(f'files[{index}] must be an image')
+        if size_bytes <= 0:
+            raise ValueError(f'files[{index}].sizeBytes must be positive')
+        if size_bytes > MAX_STATIC_PHOTO_SIZE_BYTES:
+            raise ValueError(f'files[{index}] exceeds the 50MB per-photo limit')
+        validated.append({
+            'name': name,
+            'relativePath': relative_path,
+            'contentType': content_type,
+            'sizeBytes': size_bytes,
+        })
+    return validated
+
+
+def _create_static_photo_upload_urls(user_sub: str, project_id: str, files: Any) -> Dict[str, Any]:
+    client = _get_r2_client()
+    if not client:
+        raise RuntimeError('R2 is not configured for static photo uploads.')
+    if not R2_PUBLIC_BASE_URL:
+        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads.')
+
+    validated_files = _validate_static_photo_request(files)
+    results = []
+    for file_info in validated_files:
+        object_key = _build_static_photo_key(
+            user_sub=user_sub,
+            project_id=project_id,
+            relative_path=file_info['relativePath'],
+        )
+        upload_url = client.generate_presigned_url(
+            'put_object',
+            Params={
+                'Bucket': R2_BUCKET_NAME,
+                'Key': object_key,
+                'ContentType': file_info['contentType'],
+            },
+            ExpiresIn=STATIC_PHOTO_UPLOAD_EXPIRES_SECONDS,
+        )
+        results.append({
+            **file_info,
+            'objectKey': object_key,
+            'publicUrl': _public_url_for_key(object_key),
+            'uploadUrl': upload_url,
+        })
+
+    return {
+        'bucket': R2_BUCKET_NAME,
+        'publicBaseUrl': R2_PUBLIC_BASE_URL,
+        'expiresIn': STATIC_PHOTO_UPLOAD_EXPIRES_SECONDS,
+        'files': results,
+    }
 
 
 def _resolve_viewer_slug(project: Dict[str, Any]) -> Optional[str]:
@@ -344,6 +456,25 @@ def lambda_handler(event, context):
             items = res.get('Items', [])
             return _response(200, {'projects': items})
 
+        if method == 'POST' and project_id and path.endswith('/photo-upload-urls'):
+            res = table.get_item(Key={'userSub': user_sub, 'projectId': project_id})
+            project = res.get('Item')
+            if not project:
+                return _response(404, {'error': 'Not found'})
+
+            try:
+                upload_payload = _create_static_photo_upload_urls(
+                    user_sub=user_sub,
+                    project_id=project_id,
+                    files=body.get('files'),
+                )
+            except ValueError as exc:
+                return _response(400, {'error': str(exc)})
+            except RuntimeError as exc:
+                return _response(500, {'error': str(exc)})
+
+            return _response(200, upload_payload)
+
         if method == 'POST' and not project_id:
             # Create project
             import uuid
@@ -366,7 +497,7 @@ def lambda_handler(event, context):
         if method in ('PUT', 'PATCH') and project_id:
             # Update mutable fields
             update_fields = {}
-            for key in ('title', 'status', 'progress', 'params', 'upload', 'ml'):
+            for key in ('title', 'status', 'progress', 'params', 'upload', 'ml', 'photoLibrary'):
                 if key in body:
                     # Convert floats to Decimal for DynamoDB compatibility
                     update_fields[key] = convert_floats_to_decimal(body[key])

--- a/infrastructure/spaceport_cdk/lambda/projects/lambda_function.py
+++ b/infrastructure/spaceport_cdk/lambda/projects/lambda_function.py
@@ -148,7 +148,7 @@ def _build_static_photo_key(user_sub: str, project_id: str, relative_path: str) 
 
 def _public_url_for_key(object_key: str) -> str:
     if not R2_PUBLIC_BASE_URL:
-        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads.')
+        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads. Set the deploy secret for this environment.')
     return f"{R2_PUBLIC_BASE_URL}/{object_key}"
 
 
@@ -188,7 +188,7 @@ def _create_static_photo_upload_urls(user_sub: str, project_id: str, files: Any)
     if not client:
         raise RuntimeError('R2 is not configured for static photo uploads.')
     if not R2_PUBLIC_BASE_URL:
-        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads.')
+        raise RuntimeError('R2_PUBLIC_BASE_URL is not configured for static photo uploads. Set the deploy secret for this environment.')
 
     validated_files = _validate_static_photo_request(files)
     results = []

--- a/infrastructure/spaceport_cdk/spaceport_cdk/auth_stack.py
+++ b/infrastructure/spaceport_cdk/spaceport_cdk/auth_stack.py
@@ -173,6 +173,7 @@ class AuthStack(Stack):
                 "R2_SECRET_ACCESS_KEY": os.environ.get(f"R2_SECRET_ACCESS_KEY_{suffix.upper()}", os.environ.get("R2_SECRET_ACCESS_KEY", "")),
                 "R2_BUCKET_NAME": os.environ.get(f"R2_BUCKET_NAME_{suffix.upper()}", os.environ.get("R2_BUCKET_NAME", "spaces-viewers")),
                 "R2_REGION": os.environ.get(f"R2_REGION_{suffix.upper()}", os.environ.get("R2_REGION", "auto")),
+                "R2_PUBLIC_BASE_URL": os.environ.get(f"R2_PUBLIC_BASE_URL_{suffix.upper()}", os.environ.get("R2_PUBLIC_BASE_URL", "")),
             },
         )
         # Allow the Lambda to read/write from the Projects table
@@ -270,6 +271,13 @@ class AuthStack(Stack):
         )
         proj_payment_session = proj_id.add_resource("payment-session")
         proj_payment_session.add_method(
+            "POST",
+            apigw.LambdaIntegration(projects_lambda),
+            authorization_type=apigw.AuthorizationType.COGNITO,
+            authorizer=projects_authorizer
+        )
+        proj_photo_upload_urls = proj_id.add_resource("photo-upload-urls")
+        proj_photo_upload_urls.add_method(
             "POST",
             apigw.LambdaIntegration(projects_lambda),
             authorization_type=apigw.AuthorizationType.COGNITO,

--- a/tests/unit/test_static_photo_uploads.py
+++ b/tests/unit/test_static_photo_uploads.py
@@ -94,7 +94,7 @@ def _load_module(fake_table, fake_r2):
     os.environ["R2_ACCESS_KEY_ID"] = "key"
     os.environ["R2_SECRET_ACCESS_KEY"] = "secret"
     os.environ["R2_BUCKET_NAME"] = "spaces-viewers"
-    os.environ["R2_PUBLIC_BASE_URL"] = "https://media.spcprt.com"
+    os.environ["R2_PUBLIC_BASE_URL"] = "https://spcprt.com/spaces/media"
 
     spec = importlib.util.spec_from_file_location("projects_lambda", MODULE_PATH)
     module = importlib.util.module_from_spec(spec)
@@ -160,14 +160,14 @@ class StaticPhotoUploadTests(unittest.TestCase):
         body = json.loads(response["body"])
         self.assertEqual(response["statusCode"], 200)
         self.assertEqual(body["bucket"], "spaces-viewers")
-        self.assertEqual(body["publicBaseUrl"], "https://media.spcprt.com")
+        self.assertEqual(body["publicBaseUrl"], "https://spcprt.com/spaces/media")
         self.assertEqual(
             body["files"][0]["objectKey"],
             "users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
         )
         self.assertEqual(
             body["files"][0]["publicUrl"],
-            "https://media.spcprt.com/users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+            "https://spcprt.com/spaces/media/users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
         )
         self.assertEqual(fake_r2.calls[0][0], "put_object")
         self.assertEqual(fake_r2.calls[0][1]["ContentType"], "image/jpeg")
@@ -194,7 +194,7 @@ class StaticPhotoUploadTests(unittest.TestCase):
                         "photoLibrary": {
                             "mode": "static_photos",
                             "bucket": "spaces-viewers",
-                            "publicBaseUrl": "https://media.spcprt.com",
+                            "publicBaseUrl": "https://spcprt.com/spaces/media",
                             "folders": ["Interior"],
                             "files": [
                                 {
@@ -203,7 +203,7 @@ class StaticPhotoUploadTests(unittest.TestCase):
                                     "contentType": "image/jpeg",
                                     "sizeBytes": 2048,
                                     "objectKey": "users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
-                                    "publicUrl": "https://media.spcprt.com/users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+                                    "publicUrl": "https://spcprt.com/spaces/media/users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
                                     "uploadedAt": 1770000000000,
                                 }
                             ],

--- a/tests/unit/test_static_photo_uploads.py
+++ b/tests/unit/test_static_photo_uploads.py
@@ -1,0 +1,225 @@
+import importlib.util
+import json
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "infrastructure"
+    / "spaceport_cdk"
+    / "lambda"
+    / "projects"
+    / "lambda_function.py"
+)
+
+
+class _FakeTable:
+    def __init__(self):
+        self.items = {
+            ("user-123", "project-abc"): {
+                "userSub": "user-123",
+                "projectId": "project-abc",
+                "title": "Static Photo Project",
+            }
+        }
+        self.updated = None
+
+    def get_item(self, Key):
+        item = self.items.get((Key["userSub"], Key["projectId"]))
+        return {"Item": item} if item else {}
+
+    def query(self, **kwargs):
+        return {"Items": []}
+
+    def put_item(self, Item):
+        self.items[(Item["userSub"], Item["projectId"])] = Item
+
+    def update_item(self, **kwargs):
+        self.updated = kwargs
+        return {}
+
+
+class _FakeDynamoResource:
+    def __init__(self, table):
+        self.table = table
+
+    def Table(self, name):
+        return self.table
+
+
+class _FakeR2Client:
+    def __init__(self):
+        self.calls = []
+
+    def generate_presigned_url(self, operation, Params, ExpiresIn):
+        self.calls.append((operation, Params, ExpiresIn))
+        return f"https://upload.example.test/{Params['Key']}"
+
+
+def _load_module(fake_table, fake_r2):
+    for name in ("boto3", "botocore", "botocore.config", "botocore.exceptions", "stripe"):
+        if name in sys.modules:
+            del sys.modules[name]
+
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.resource = lambda *args, **kwargs: _FakeDynamoResource(fake_table)
+    fake_boto3.client = lambda *args, **kwargs: fake_r2
+    fake_boto3.dynamodb = types.SimpleNamespace(
+        conditions=types.SimpleNamespace(Key=lambda name: name)
+    )
+    sys.modules["boto3"] = fake_boto3
+
+    fake_botocore = types.ModuleType("botocore")
+    fake_botocore_config = types.ModuleType("botocore.config")
+    fake_botocore_config.Config = lambda *args, **kwargs: None
+    fake_botocore_exceptions = types.ModuleType("botocore.exceptions")
+    fake_botocore_exceptions.ClientError = Exception
+    sys.modules["botocore"] = fake_botocore
+    sys.modules["botocore.config"] = fake_botocore_config
+    sys.modules["botocore.exceptions"] = fake_botocore_exceptions
+
+    fake_stripe = types.ModuleType("stripe")
+    fake_stripe.api_key = None
+    fake_stripe.checkout = types.SimpleNamespace(Session=types.SimpleNamespace(create=lambda **kwargs: None))
+    fake_stripe.Subscription = types.SimpleNamespace(delete=lambda subscription_id: None)
+    fake_stripe.error = types.SimpleNamespace(StripeError=Exception)
+    sys.modules["stripe"] = fake_stripe
+
+    os.environ["PROJECTS_TABLE_NAME"] = "Projects"
+    os.environ["R2_ENDPOINT"] = "https://example.r2.cloudflarestorage.com"
+    os.environ["R2_ACCESS_KEY_ID"] = "key"
+    os.environ["R2_SECRET_ACCESS_KEY"] = "secret"
+    os.environ["R2_BUCKET_NAME"] = "spaces-viewers"
+    os.environ["R2_PUBLIC_BASE_URL"] = "https://media.spcprt.com"
+
+    spec = importlib.util.spec_from_file_location("projects_lambda", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _event(path, body):
+    return {
+        "httpMethod": "POST",
+        "path": path,
+        "pathParameters": {"id": "project-abc"},
+        "requestContext": {
+            "authorizer": {
+                "claims": {
+                    "sub": "user-123",
+                    "email": "owner@example.test",
+                }
+            }
+        },
+        "body": json.dumps(body),
+    }
+
+
+class StaticPhotoUploadTests(unittest.TestCase):
+    def test_photo_keys_preserve_safe_folder_structure(self):
+        module = _load_module(_FakeTable(), _FakeR2Client())
+
+        key = module._build_static_photo_key(
+            user_sub="user-123",
+            project_id="project-abc",
+            relative_path="Interior/Kitchen Hero.JPG",
+        )
+
+        self.assertEqual(
+            key,
+            "users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+        )
+
+    def test_presign_endpoint_returns_public_urls_and_metadata(self):
+        fake_table = _FakeTable()
+        fake_r2 = _FakeR2Client()
+        module = _load_module(fake_table, fake_r2)
+
+        response = module.lambda_handler(
+            _event(
+                "/projects/project-abc/photo-upload-urls",
+                {
+                    "files": [
+                        {
+                            "name": "Kitchen Hero.JPG",
+                            "relativePath": "Interior/Kitchen Hero.JPG",
+                            "contentType": "image/jpeg",
+                            "sizeBytes": 2048,
+                        }
+                    ]
+                },
+            ),
+            None,
+        )
+
+        body = json.loads(response["body"])
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(body["bucket"], "spaces-viewers")
+        self.assertEqual(body["publicBaseUrl"], "https://media.spcprt.com")
+        self.assertEqual(
+            body["files"][0]["objectKey"],
+            "users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+        )
+        self.assertEqual(
+            body["files"][0]["publicUrl"],
+            "https://media.spcprt.com/users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+        )
+        self.assertEqual(fake_r2.calls[0][0], "put_object")
+        self.assertEqual(fake_r2.calls[0][1]["ContentType"], "image/jpeg")
+
+    def test_project_patch_accepts_photo_library_metadata(self):
+        fake_table = _FakeTable()
+        module = _load_module(fake_table, _FakeR2Client())
+
+        response = module.lambda_handler(
+            {
+                "httpMethod": "PATCH",
+                "path": "/projects/project-abc",
+                "pathParameters": {"id": "project-abc"},
+                "requestContext": {
+                    "authorizer": {
+                        "claims": {
+                            "sub": "user-123",
+                            "email": "owner@example.test",
+                        }
+                    }
+                },
+                "body": json.dumps(
+                    {
+                        "photoLibrary": {
+                            "mode": "static_photos",
+                            "bucket": "spaces-viewers",
+                            "publicBaseUrl": "https://media.spcprt.com",
+                            "folders": ["Interior"],
+                            "files": [
+                                {
+                                    "originalName": "Kitchen Hero.JPG",
+                                    "relativePath": "Interior/Kitchen Hero.JPG",
+                                    "contentType": "image/jpeg",
+                                    "sizeBytes": 2048,
+                                    "objectKey": "users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+                                    "publicUrl": "https://media.spcprt.com/users/user-123/projects/project-abc/photos/Interior/Kitchen%20Hero.JPG",
+                                    "uploadedAt": 1770000000000,
+                                }
+                            ],
+                            "uploadedAt": 1770000000000,
+                        }
+                    }
+                ),
+            },
+            None,
+        )
+
+        self.assertEqual(response["statusCode"], 200)
+        expression_names = fake_table.updated["ExpressionAttributeNames"]
+        self.assertIn("#photoLibrary", expression_names)
+        self.assertEqual(expression_names["#photoLibrary"], "photoLibrary")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/components/NewProjectModal.tsx
+++ b/web/components/NewProjectModal.tsx
@@ -1758,32 +1758,20 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
             <div className="popup-section">
               <div className="category-outline">
                 <div className="popup-section">
-                  <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+                  <div className="upload-mode-switcher" role="group" aria-label="Property upload type">
                     <button
                       type="button"
+                      className={`upload-mode-option${uploadMode === 'model_photos' ? ' active' : ''}`}
                       onClick={() => setUploadMode('model_photos')}
-                      style={{
-                        padding: '10px 16px',
-                        borderRadius: 999,
-                        border: uploadMode === 'model_photos' ? '1px solid #60a5fa' : '1px solid rgba(255,255,255,0.2)',
-                        background: uploadMode === 'model_photos' ? 'rgba(96,165,250,0.18)' : 'transparent',
-                        color: '#fff',
-                        cursor: 'pointer',
-                      }}
+                      aria-pressed={uploadMode === 'model_photos'}
                     >
                       3D Model Photos
                     </button>
                     <button
                       type="button"
+                      className={`upload-mode-option${uploadMode === 'static_photos' ? ' active' : ''}`}
                       onClick={() => setUploadMode('static_photos')}
-                      style={{
-                        padding: '10px 16px',
-                        borderRadius: 999,
-                        border: uploadMode === 'static_photos' ? '1px solid #60a5fa' : '1px solid rgba(255,255,255,0.2)',
-                        background: uploadMode === 'static_photos' ? 'rgba(96,165,250,0.18)' : 'transparent',
-                        color: '#fff',
-                        cursor: 'pointer',
-                      }}
+                      aria-pressed={uploadMode === 'static_photos'}
                     >
                       Static Property Photos
                     </button>

--- a/web/components/NewProjectModal.tsx
+++ b/web/components/NewProjectModal.tsx
@@ -1877,7 +1877,7 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                   <div className="upload-button-container">
                     <button className={`upload-btn-with-icon${uploadLoading ? ' loading' : ''}`} onClick={startUpload} disabled={uploadLoading}>
                       <span className="upload-btn-icon"></span>
-                      {uploadLoading ? 'Uploading...' : mlLoading ? 'Starting ML...' : uploadMode === 'static_photos' ? 'Upload Photos' : 'Upload'}
+                      {uploadLoading ? 'Uploading...' : mlLoading ? 'Starting ML...' : 'Upload'}
                     </button>
                     <button className="cancel-btn-with-icon" disabled={uploadLoading} onClick={() => onClose()}>
                       <span className="cancel-btn-icon"></span>

--- a/web/components/NewProjectModal.tsx
+++ b/web/components/NewProjectModal.tsx
@@ -18,6 +18,22 @@ type OptimizedParams = {
   formToTerrain: boolean;
 };
 
+type UploadMode = 'model_photos' | 'static_photos';
+
+type StaticPhotoFile = File & {
+  webkitRelativePath?: string;
+};
+
+type UploadedStaticPhoto = {
+  originalName: string;
+  relativePath: string;
+  contentType: string;
+  sizeBytes: number;
+  objectKey: string;
+  publicUrl: string;
+  uploadedAt: number;
+};
+
 function normalizeTerrainToggle(value: unknown): boolean {
   return value === true || value === "true";
 }
@@ -37,13 +53,13 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
 
   // Use centralized API configuration instead of hardcoded values
   const API_ENHANCED_BASE = buildApiUrl.dronePath.optimizeSpiral().replace('/api/optimize-spiral', '');
-  const API_UPLOAD = {
+  const API_UPLOAD = useMemo(() => ({
     START_UPLOAD: buildApiUrl.fileUpload.startUpload(),
     GET_PRESIGNED_URL: buildApiUrl.fileUpload.getPresignedUrl(),
     COMPLETE_UPLOAD: buildApiUrl.fileUpload.completeUpload(),
     SAVE_SUBMISSION: buildApiUrl.fileUpload.saveSubmission(),
     START_ML_PROCESSING: buildApiUrl.mlPipeline.startJob(),
-  } as const;
+  } as const), []);
 
   const CHUNK_SIZE = 64 * 1024 * 1024; // 64MB - industry standard for optimal speed/reliability balance
   const MAX_FILE_SIZE = 20 * 1024 * 1024 * 1024; // 20GB
@@ -65,6 +81,10 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
   const [locationCityState, setLocationCityState] = useState<string>("");
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadMode, setUploadMode] = useState<UploadMode>('model_photos');
+  const [selectedStaticFiles, setSelectedStaticFiles] = useState<StaticPhotoFile[]>([]);
+  const [uploadedStaticPhotos, setUploadedStaticPhotos] = useState<UploadedStaticPhoto[]>([]);
+  const [copiedPhotoUrl, setCopiedPhotoUrl] = useState<string | null>(null);
   const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [uploadLoading, setUploadLoading] = useState<boolean>(false);
   const [mlLoading, setMlLoading] = useState<boolean>(false);
@@ -195,6 +215,11 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
     setUploadLoading(false);
     setMlLoading(false);
     setUploadStage('');
+    setUploadMode(project?.photoLibrary?.mode === 'static_photos' ? 'static_photos' : 'model_photos');
+    setSelectedFile(null);
+    setSelectedStaticFiles([]);
+    setUploadedStaticPhotos(Array.isArray(project?.photoLibrary?.files) ? project.photoLibrary.files : []);
+    setCopiedPhotoUrl(null);
     setOptimizedParamsWithLogging(null, 'Modal opened/reset');
     setDownloadingBatteries(new Set());
     setSetupOpen(true);
@@ -794,9 +819,9 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
   }, [API_ENHANCED_BASE, projectTitle, downloadingBatteries]);
 
   // SIMPLE, ROBUST save function with rate limiting
-  const saveProject = useCallback(async () => {
+  const saveProject = useCallback(async (): Promise<string | null> => {
     // Prevent multiple simultaneous saves
-    if (isSaving) return;
+    if (isSaving) return currentProjectId;
     
     try {
       setIsSaving(true);
@@ -850,13 +875,19 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
       if (!currentProjectId) {
         const data = await res.json().catch(() => ({} as any));
         const created = (data && (data.project || data)) as any;
-        if (created && created.projectId) setCurrentProjectId(created.projectId);
+        if (created && created.projectId) {
+          setCurrentProjectId(created.projectId);
+          onSaved?.();
+          return created.projectId;
+        }
       }
       
       onSaved?.();
+      return currentProjectId;
     } catch (e: any) {
       console.error('Save failed:', e);
       showSystemNotification('error', e?.message || 'Failed to save project');
+      return null;
     } finally {
       setIsSaving(false);
     }
@@ -887,10 +918,17 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
     const hasBatteryData = Boolean(batteryMinutes || numBatteries);
     const hasAltitudeData = Boolean(minHeightFeet || maxHeightFeet);
     const hasTitleChange = projectTitle !== 'Untitled' && projectTitle.trim();
-    const hasUploadData = Boolean(propertyTitle.trim() || listingDescription.trim() || contactEmail.trim() || selectedFile);
+    const hasUploadData = Boolean(
+      propertyTitle.trim()
+      || listingDescription.trim()
+      || contactEmail.trim()
+      || selectedFile
+      || selectedStaticFiles.length > 0
+      || uploadMode === 'static_photos'
+    );
     
     return hasLocation || hasBatteryData || hasAltitudeData || hasTitleChange || hasUploadData;
-  }, [currentProjectId, addressSearch, batteryMinutes, numBatteries, minHeightFeet, maxHeightFeet, projectTitle, propertyTitle, listingDescription, contactEmail, selectedFile, selectedCoords]);
+  }, [currentProjectId, addressSearch, batteryMinutes, numBatteries, minHeightFeet, maxHeightFeet, projectTitle, propertyTitle, listingDescription, contactEmail, selectedFile, selectedStaticFiles.length, selectedCoords, uploadMode]);
 
   // SIMPLE debounced save trigger
   const triggerSave = useCallback(() => {
@@ -1007,7 +1045,25 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
     setSelectedFile(file);
   }, []);
 
+  const getStaticPhotoRelativePath = useCallback((file: StaticPhotoFile) => {
+    return file.webkitRelativePath || file.name;
+  }, []);
+
+  const onStaticFilesChosen = useCallback((files: FileList | File[] | null) => {
+    const imageFiles = Array.from(files || [])
+      .filter((file): file is StaticPhotoFile => file.type.startsWith('image/'));
+    setSelectedStaticFiles(imageFiles);
+    setUploadedStaticPhotos([]);
+    setCopiedPhotoUrl(null);
+  }, []);
+
   const validateUpload = useCallback(() => {
+    if (uploadMode === 'static_photos') {
+      if (selectedStaticFiles.length === 0) return 'Please select at least one image';
+      const tooLarge = selectedStaticFiles.find((file) => file.size > 50 * 1024 * 1024);
+      if (tooLarge) return `${tooLarge.name} exceeds the 50MB per-photo limit`;
+      return null;
+    }
     if (!propertyTitle.trim()) return 'Property title is required';
     if (!contactEmail.trim()) return 'Email address is required';
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -1016,9 +1072,149 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
     if (!selectedFile.name.toLowerCase().endsWith('.zip')) return 'Please upload a .zip file only';
     if (selectedFile.size > MAX_FILE_SIZE) return 'File size exceeds 20GB limit';
     return null;
-  }, [propertyTitle, contactEmail, selectedFile]);
+  }, [MAX_FILE_SIZE, contactEmail, propertyTitle, selectedFile, selectedStaticFiles, uploadMode]);
+
+  const copyPhotoUrl = useCallback(async (url: string) => {
+    await navigator.clipboard.writeText(url);
+    setCopiedPhotoUrl(url);
+    setTimeout(() => setCopiedPhotoUrl((current) => current === url ? null : current), 1800);
+  }, []);
+
+  const startStaticPhotoUpload = useCallback(async () => {
+    const validationError = validateUpload();
+    if (validationError) {
+      showSystemNotification('error', validationError);
+      return;
+    }
+
+    setUploadLoading(true);
+    setMlLoading(false);
+    setUploadProgress(0);
+    setUploadStage('Preparing photo upload...');
+    try {
+      const { Auth } = await import('aws-amplify');
+      const session = await Auth.currentSession();
+      const idToken = session.getIdToken().getJwtToken();
+      const apiEnv = process.env.NEXT_PUBLIC_PROJECTS_API_URL;
+      if (!apiEnv) throw new Error('Projects API URL is not configured');
+      const apiBase = apiEnv.replace(/\/$/, '');
+      const projectId = currentProjectId || await saveProject();
+      if (!projectId) throw new Error('Create or save the project before uploading photos');
+
+      const requestFiles = selectedStaticFiles.map((file) => ({
+        name: file.name,
+        relativePath: getStaticPhotoRelativePath(file),
+        contentType: file.type || 'application/octet-stream',
+        sizeBytes: file.size,
+      }));
+
+      const presignRes = await fetch(`${apiBase}/${encodeURIComponent(projectId)}/photo-upload-urls`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: `Bearer ${idToken}` },
+        body: JSON.stringify({ files: requestFiles }),
+      });
+      if (!presignRes.ok) {
+        const message = await readApiErrorMessage(presignRes, `Photo upload setup failed: ${presignRes.status}`);
+        throw new Error(message);
+      }
+
+      const presigned = await presignRes.json();
+      const uploadTargets = Array.isArray(presigned.files) ? presigned.files : [];
+      if (uploadTargets.length !== selectedStaticFiles.length) {
+        throw new Error('Photo upload setup returned an unexpected file count');
+      }
+
+      const uploadedAt = Date.now();
+      const uploaded: UploadedStaticPhoto[] = [];
+      const uploadOne = async (index: number) => {
+        const file = selectedStaticFiles[index];
+        const target = uploadTargets[index];
+        const putRes = await fetch(target.uploadUrl, {
+          method: 'PUT',
+          headers: { 'Content-Type': target.contentType || file.type || 'application/octet-stream' },
+          body: file,
+        });
+        if (!putRes.ok) throw new Error(`Failed to upload ${file.name}: ${putRes.status}`);
+        uploaded[index] = {
+          originalName: file.name,
+          relativePath: getStaticPhotoRelativePath(file),
+          contentType: target.contentType || file.type || 'application/octet-stream',
+          sizeBytes: file.size,
+          objectKey: target.objectKey,
+          publicUrl: target.publicUrl,
+          uploadedAt,
+        };
+        setUploadProgress(((uploaded.filter(Boolean).length) / selectedStaticFiles.length) * 95);
+      };
+
+      setUploadStage(`Uploading ${selectedStaticFiles.length} photo${selectedStaticFiles.length === 1 ? '' : 's'}...`);
+      const maxConcurrentUploads = 6;
+      let nextIndex = 0;
+      const workers = Array.from({ length: Math.min(maxConcurrentUploads, selectedStaticFiles.length) }, async () => {
+        while (nextIndex < selectedStaticFiles.length) {
+          const index = nextIndex;
+          nextIndex += 1;
+          await uploadOne(index);
+        }
+      });
+      await Promise.all(workers);
+
+      const folderSet = new Set(uploaded.map((file) => {
+        const parts = file.relativePath.split('/').filter(Boolean);
+        parts.pop();
+        return parts.join('/') || 'Root';
+      }));
+      const photoLibrary = {
+        mode: 'static_photos',
+        bucket: presigned.bucket,
+        publicBaseUrl: presigned.publicBaseUrl,
+        folders: Array.from(folderSet).sort(),
+        files: uploaded,
+        uploadedAt,
+      };
+
+      setUploadStage('Saving photo library...');
+      const saveRes = await fetch(`${apiBase}/${encodeURIComponent(projectId)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json', Authorization: `Bearer ${idToken}` },
+        body: JSON.stringify({
+          status: 'photos_uploaded',
+          progress: 50,
+          photoLibrary,
+        }),
+      });
+      if (!saveRes.ok) {
+        const message = await readApiErrorMessage(saveRes, `Failed to save photo library: ${saveRes.status}`);
+        throw new Error(message);
+      }
+
+      setUploadProgress(100);
+      setUploadStage('Static photos uploaded');
+      setStatus('photos_uploaded');
+      setUploadedStaticPhotos(uploaded);
+      onSaved?.();
+      showSystemNotification('success', 'Static photos uploaded and linked to this project.');
+    } catch (e: any) {
+      showSystemNotification('error', e?.message || 'Static photo upload failed');
+    } finally {
+      setUploadLoading(false);
+      setTimeout(() => setUploadStage(''), 3000);
+    }
+  }, [
+    currentProjectId,
+    getStaticPhotoRelativePath,
+    onSaved,
+    saveProject,
+    selectedStaticFiles,
+    showSystemNotification,
+    validateUpload,
+  ]);
 
   const startUpload = useCallback(async () => {
+    if (uploadMode === 'static_photos') {
+      await startStaticPhotoUpload();
+      return;
+    }
     const validationError = validateUpload();
     if (validationError) {
       showSystemNotification('error', validationError);
@@ -1236,7 +1432,25 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
       // Keep stage text visible for a few seconds after completion
       setTimeout(() => setUploadStage(''), 3000);
     }
-  }, [API_UPLOAD, CHUNK_SIZE, MAX_FILE_SIZE, propertyTitle, contactEmail, listingDescription, selectedFile, validateUpload]);
+  }, [
+    API_UPLOAD,
+    CHUNK_SIZE,
+    addressSearch,
+    batteryMinutes,
+    contactEmail,
+    formToTerrain,
+    listingDescription,
+    maxHeightFeet,
+    minHeightFeet,
+    numBatteries,
+    projectTitle,
+    propertyTitle,
+    selectedFile,
+    showSystemNotification,
+    startStaticPhotoUpload,
+    uploadMode,
+    validateUpload,
+  ]);
 
   if (!open) return null;
 
@@ -1544,14 +1758,97 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
             <div className="popup-section">
               <div className="category-outline">
                 <div className="popup-section">
-                  <div className="upload-zone" onClick={() => document.getElementById('fileInputHidden')?.click()} onDragOver={(e) => { e.preventDefault(); }} onDrop={(e) => { e.preventDefault(); const f = e.dataTransfer.files?.[0]; if (f) onFileChosen(f); }}>
+                  <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+                    <button
+                      type="button"
+                      onClick={() => setUploadMode('model_photos')}
+                      style={{
+                        padding: '10px 16px',
+                        borderRadius: 999,
+                        border: uploadMode === 'model_photos' ? '1px solid #60a5fa' : '1px solid rgba(255,255,255,0.2)',
+                        background: uploadMode === 'model_photos' ? 'rgba(96,165,250,0.18)' : 'transparent',
+                        color: '#fff',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      3D Model Photos
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setUploadMode('static_photos')}
+                      style={{
+                        padding: '10px 16px',
+                        borderRadius: 999,
+                        border: uploadMode === 'static_photos' ? '1px solid #60a5fa' : '1px solid rgba(255,255,255,0.2)',
+                        background: uploadMode === 'static_photos' ? 'rgba(96,165,250,0.18)' : 'transparent',
+                        color: '#fff',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Static Property Photos
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="category-outline">
+                <div className="popup-section">
+                  <div
+                    className="upload-zone"
+                    onClick={() => document.getElementById(uploadMode === 'static_photos' ? 'staticFilesInputHidden' : 'fileInputHidden')?.click()}
+                    onDragOver={(e) => { e.preventDefault(); }}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      if (uploadMode === 'static_photos') {
+                        onStaticFilesChosen(e.dataTransfer.files);
+                        return;
+                      }
+                      const f = e.dataTransfer.files?.[0];
+                      if (f) onFileChosen(f);
+                    }}
+                  >
                     <div className="upload-icon"></div>
-                    {!selectedFile && <p>Upload .jpg photos as a .zip file</p>}
-                    {selectedFile && (
+                    {uploadMode === 'model_photos' && !selectedFile && <p>Upload .jpg photos as a .zip file</p>}
+                    {uploadMode === 'model_photos' && selectedFile && (
                       <p id="selectedFileDisplay">Selected file: <span id="selectedFileName">{selectedFile.name}</span> <span className="close-icon" onClick={(e) => { e.stopPropagation(); onFileChosen(null); }}>&times;</span></p>
                     )}
+                    {uploadMode === 'static_photos' && selectedStaticFiles.length === 0 && <p>Select image files or a folder</p>}
+                    {uploadMode === 'static_photos' && selectedStaticFiles.length > 0 && (
+                      <p id="selectedFileDisplay">
+                        Selected: <span id="selectedFileName">{selectedStaticFiles.length} photo{selectedStaticFiles.length === 1 ? '' : 's'}</span>
+                        <span className="close-icon" onClick={(e) => { e.stopPropagation(); onStaticFilesChosen(null); }}>&times;</span>
+                      </p>
+                    )}
                     <input id="fileInputHidden" type="file" accept=".zip" style={{ display: 'none' }} onChange={(e) => onFileChosen(e.target.files?.[0] || null)} />
+                    <input id="staticFilesInputHidden" type="file" accept="image/*" multiple style={{ display: 'none' }} onChange={(e) => onStaticFilesChosen(e.target.files)} />
+                    <input
+                      id="staticFolderInputHidden"
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      style={{ display: 'none' }}
+                      onChange={(e) => onStaticFilesChosen(e.target.files)}
+                      {...({ webkitdirectory: '', directory: '' } as any)}
+                    />
                   </div>
+                  {uploadMode === 'static_photos' && (
+                    <div style={{ display: 'flex', justifyContent: 'center', marginTop: 10 }}>
+                      <button
+                        type="button"
+                        onClick={() => document.getElementById('staticFolderInputHidden')?.click()}
+                        style={{
+                          border: '1px solid rgba(255,255,255,0.22)',
+                          borderRadius: 999,
+                          background: 'rgba(255,255,255,0.06)',
+                          color: '#fff',
+                          padding: '8px 14px',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Choose Folder
+                      </button>
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -1573,7 +1870,7 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
 
               <div className="category-outline">
                 <div className="popup-section">
-                  <h4>Delivery Method</h4>
+                  <h4>{uploadMode === 'static_photos' ? 'Contact' : 'Delivery Method'}</h4>
                   <div className="input-row-popup">
                     <div className="popup-input-wrapper">
                       <span className="input-icon email"></span>
@@ -1607,7 +1904,7 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                   <div className="upload-button-container">
                     <button className={`upload-btn-with-icon${uploadLoading ? ' loading' : ''}`} onClick={startUpload} disabled={uploadLoading}>
                       <span className="upload-btn-icon"></span>
-                      {uploadLoading ? 'Uploading…' : mlLoading ? 'Starting ML…' : 'Upload'}
+                      {uploadLoading ? 'Uploading...' : mlLoading ? 'Starting ML...' : uploadMode === 'static_photos' ? 'Upload Photos' : 'Upload'}
                     </button>
                     <button className="cancel-btn-with-icon" disabled={uploadLoading} onClick={() => onClose()}>
                       <span className="cancel-btn-icon"></span>
@@ -1625,6 +1922,49 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                   </div>
                 </div>
               </div>
+
+              {uploadMode === 'static_photos' && uploadedStaticPhotos.length > 0 && (
+                <div className="category-outline">
+                  <div className="popup-section">
+                    <h4>Photo Links</h4>
+                    <div style={{ display: 'grid', gap: 8, maxHeight: 220, overflow: 'auto' }}>
+                      {uploadedStaticPhotos.map((photo) => (
+                        <div
+                          key={photo.objectKey}
+                          style={{
+                            display: 'grid',
+                            gridTemplateColumns: 'minmax(0, 1fr) auto',
+                            gap: 8,
+                            alignItems: 'center',
+                            padding: '8px 10px',
+                            border: '1px solid rgba(255,255,255,0.12)',
+                            borderRadius: 8,
+                          }}
+                        >
+                          <div style={{ minWidth: 0 }}>
+                            <div style={{ color: '#fff', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{photo.relativePath}</div>
+                            <div style={{ color: 'rgba(255,255,255,0.58)', fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{photo.publicUrl}</div>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => copyPhotoUrl(photo.publicUrl)}
+                            style={{
+                              border: '1px solid rgba(255,255,255,0.22)',
+                              borderRadius: 999,
+                              background: copiedPhotoUrl === photo.publicUrl ? 'rgba(74,222,128,0.18)' : 'rgba(255,255,255,0.06)',
+                              color: '#fff',
+                              padding: '7px 12px',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            {copiedPhotoUrl === photo.publicUrl ? 'Copied' : 'Copy URL'}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {/* Error messages now shown as popups via toast state */}
             </div>

--- a/web/components/NewProjectModal.tsx
+++ b/web/components/NewProjectModal.tsx
@@ -1758,14 +1758,18 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
             <div className="popup-section">
               <div className="category-outline">
                 <div className="popup-section">
-                  <div className="upload-mode-switcher" role="group" aria-label="Property upload type">
+                  <div
+                    className={`upload-mode-switcher upload-mode-switcher--${uploadMode === 'model_photos' ? 'model' : 'static'}`}
+                    role="group"
+                    aria-label="Property upload type"
+                  >
                     <button
                       type="button"
                       className={`upload-mode-option${uploadMode === 'model_photos' ? ' active' : ''}`}
                       onClick={() => setUploadMode('model_photos')}
                       aria-pressed={uploadMode === 'model_photos'}
                     >
-                      3D Model Photos
+                      <span className="upload-mode-label">3D Model Photos</span>
                     </button>
                     <button
                       type="button"
@@ -1773,7 +1777,7 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                       onClick={() => setUploadMode('static_photos')}
                       aria-pressed={uploadMode === 'static_photos'}
                     >
-                      Static Property Photos
+                      <span className="upload-mode-label">Static Property Photos</span>
                     </button>
                   </div>
                 </div>

--- a/web/components/NewProjectModal.tsx
+++ b/web/components/NewProjectModal.tsx
@@ -1777,7 +1777,7 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                       onClick={() => setUploadMode('static_photos')}
                       aria-pressed={uploadMode === 'static_photos'}
                     >
-                      <span className="upload-mode-label">Static Property Photos</span>
+                      <span className="upload-mode-label">Static Photos</span>
                     </button>
                   </div>
                 </div>

--- a/web/components/NewProjectModal.tsx
+++ b/web/components/NewProjectModal.tsx
@@ -1787,7 +1787,7 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                 <div className="popup-section">
                   <div
                     className="upload-zone"
-                    onClick={() => document.getElementById(uploadMode === 'static_photos' ? 'staticFilesInputHidden' : 'fileInputHidden')?.click()}
+                    onClick={() => document.getElementById(uploadMode === 'static_photos' ? 'staticFolderInputHidden' : 'fileInputHidden')?.click()}
                     onDragOver={(e) => { e.preventDefault(); }}
                     onDrop={(e) => {
                       e.preventDefault();
@@ -1812,7 +1812,6 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                       </p>
                     )}
                     <input id="fileInputHidden" type="file" accept=".zip" style={{ display: 'none' }} onChange={(e) => onFileChosen(e.target.files?.[0] || null)} />
-                    <input id="staticFilesInputHidden" type="file" accept="image/*" multiple style={{ display: 'none' }} onChange={(e) => onStaticFilesChosen(e.target.files)} />
                     <input
                       id="staticFolderInputHidden"
                       type="file"
@@ -1823,24 +1822,6 @@ export default function NewProjectModal({ open, onClose, project, onSaved }: New
                       {...({ webkitdirectory: '', directory: '' } as any)}
                     />
                   </div>
-                  {uploadMode === 'static_photos' && (
-                    <div style={{ display: 'flex', justifyContent: 'center', marginTop: 10 }}>
-                      <button
-                        type="button"
-                        onClick={() => document.getElementById('staticFolderInputHidden')?.click()}
-                        style={{
-                          border: '1px solid rgba(255,255,255,0.22)',
-                          borderRadius: 999,
-                          background: 'rgba(255,255,255,0.06)',
-                          color: '#fff',
-                          padding: '8px 14px',
-                          cursor: 'pointer',
-                        }}
-                      >
-                        Choose Folder
-                      </button>
-                    </div>
-                  )}
                 </div>
               </div>
 

--- a/web/lib/canyon-vista/canyonVistaOverlays.ts
+++ b/web/lib/canyon-vista/canyonVistaOverlays.ts
@@ -4,8 +4,12 @@
 import type { V3 } from "./types";
 
 export const CANYON_VISTA_REMOTE_BASE = "https://raw.githubusercontent.com/HansenHomeAI/Canyon-Vista/main";
+const ABSOLUTE_PHOTO_URL_PATTERN = /^(https:|http:|data:|blob:)/i;
 
 export function canyonAssetUrl(relativePath: string): string {
+  if (ABSOLUTE_PHOTO_URL_PATTERN.test(relativePath)) {
+    return relativePath;
+  }
   const p = relativePath.startsWith("/") ? relativePath.slice(1) : relativePath;
   return `${CANYON_VISTA_REMOTE_BASE}/${p}`;
 }
@@ -15,7 +19,7 @@ export type TapDotConfig = {
   scale: number;
   icon: "camera" | "info";
   caption: string;
-  /** Paths relative to Canyon-Vista repo root (e.g. assets/playground/...) */
+  /** Paths relative to Canyon-Vista repo root, or full public image URLs. */
   photos: string[];
 };
 

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -4989,6 +4989,60 @@ body.popup-open {
   margin-top: 16px;
 }
 
+.upload-mode-switcher {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-height: 56px;
+  padding: 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  box-sizing: border-box;
+}
+
+.upload-mode-option {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 46px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.72);
+  font: inherit;
+  font-size: 1.2rem;
+  font-weight: 500;
+  line-height: 1.15;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+.upload-mode-option.active {
+  background: rgba(0, 0, 0, 0.82);
+  color: #fff;
+}
+
+.upload-mode-option:hover {
+  color: #fff;
+}
+
+.upload-mode-option:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.95);
+  outline-offset: 2px;
+}
+
+@media (max-width: 430px) {
+  .upload-mode-switcher {
+    gap: 2px;
+    padding: 4px;
+  }
+
+  .upload-mode-option {
+    font-size: 1rem;
+  }
+}
+
 .category-outline h4 {
   color: #fff;
   font-size: 1.2rem;

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -4990,56 +4990,103 @@ body.popup-open {
 }
 
 .upload-mode-switcher {
+  --upload-mode-gap: 4px;
+  --upload-mode-padding: 0px;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--upload-mode-gap);
   width: 100%;
   min-height: 56px;
-  padding: 5px;
+  padding: var(--upload-mode-padding);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
+  background: transparent;
   box-sizing: border-box;
+  position: relative;
+  isolation: isolate;
+}
+
+.upload-mode-switcher::before {
+  content: "";
+  position: absolute;
+  top: var(--upload-mode-padding);
+  bottom: var(--upload-mode-padding);
+  left: var(--upload-mode-padding);
+  width: calc((100% - var(--upload-mode-gap) - (var(--upload-mode-padding) * 2)) / 2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateX(0);
+  transition: transform 0.28s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.2s ease;
+  z-index: 0;
+}
+
+.upload-mode-switcher--static::before {
+  transform: translateX(calc(100% + var(--upload-mode-gap)));
 }
 
 .upload-mode-option {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex: 1 1 0;
   min-width: 0;
-  min-height: 46px;
+  min-height: 54px;
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(255, 255, 255, 0.48);
   font: inherit;
-  font-size: 1.2rem;
+  font-size: 1.08rem;
   font-weight: 500;
   line-height: 1.15;
   white-space: nowrap;
+  padding: 0 20px;
   cursor: pointer;
-  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  transition: color 0.22s ease, transform 0.22s ease;
 }
 
 .upload-mode-option.active {
-  background: rgba(0, 0, 0, 0.82);
+  background: transparent;
   color: #fff;
 }
 
 .upload-mode-option:hover {
-  color: #fff;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.upload-mode-option:focus {
+  outline: none;
 }
 
 .upload-mode-option:focus-visible {
-  outline: 2px solid rgba(96, 165, 250, 0.95);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+}
+
+.upload-mode-label {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: clip;
+  text-align: center;
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 20px), transparent);
+  mask-image: linear-gradient(to right, #000 calc(100% - 20px), transparent);
 }
 
 @media (max-width: 430px) {
   .upload-mode-switcher {
     gap: 2px;
-    padding: 4px;
+    --upload-mode-gap: 2px;
   }
 
   .upload-mode-option {
-    font-size: 1rem;
+    font-size: 0.98rem;
+    padding: 0 14px;
   }
 }
 

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -4996,7 +4996,7 @@ body.popup-open {
   align-items: center;
   gap: var(--upload-mode-gap);
   width: 100%;
-  min-height: 56px;
+  min-height: 46px;
   padding: var(--upload-mode-padding);
   border-radius: 999px;
   background: transparent;
@@ -5015,7 +5015,7 @@ body.popup-open {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.16);
   transform: translateX(0);
-  transition: transform 0.28s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.2s ease;
+  transition: transform 0.28s cubic-bezier(0.2, 0.8, 0.2, 1);
   z-index: 0;
 }
 
@@ -5029,7 +5029,7 @@ body.popup-open {
   justify-content: center;
   flex: 1 1 0;
   min-width: 0;
-  min-height: 54px;
+  min-height: 44px;
   border: 0;
   border-radius: 999px;
   background: transparent;
@@ -5039,21 +5039,17 @@ body.popup-open {
   font-weight: 500;
   line-height: 1.15;
   white-space: nowrap;
-  padding: 0 20px;
+  padding: 0 18px;
   cursor: pointer;
   position: relative;
   z-index: 1;
   overflow: hidden;
-  transition: color 0.22s ease, transform 0.22s ease;
+  transition: none;
 }
 
 .upload-mode-option.active {
   background: transparent;
   color: #fff;
-}
-
-.upload-mode-option:hover {
-  color: rgba(255, 255, 255, 0.82);
 }
 
 .upload-mode-option:focus {

--- a/web/scripts/test-canyon-photo-url-pass-through.mjs
+++ b/web/scripts/test-canyon-photo-url-pass-through.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const overlaySource = fs.readFileSync(
+  path.resolve("lib/canyon-vista/canyonVistaOverlays.ts"),
+  "utf8",
+);
+
+assert.match(
+  overlaySource,
+  /ABSOLUTE_PHOTO_URL_PATTERN/,
+  "canyon photo helper should explicitly detect absolute photo URLs",
+);
+assert.match(
+  overlaySource,
+  /return relativePath;/,
+  "absolute photo URLs should be returned unchanged",
+);
+assert.match(
+  overlaySource,
+  /https:\|http:\|data:\|blob:/,
+  "http, https, data, and blob photo URLs should pass through",
+);
+
+console.log("OK canyon photo URL pass-through helper is present");

--- a/web/scripts/test-static-photo-upload-ui-source.mjs
+++ b/web/scripts/test-static-photo-upload-ui-source.mjs
@@ -27,6 +27,12 @@ assert.doesNotMatch(
 
 assert.doesNotMatch(
   modalSource,
+  /Upload Photos/,
+  "static photo submit button should use the same Upload label as model photo mode",
+);
+
+assert.doesNotMatch(
+  modalSource,
   /staticFilesInputHidden/,
   "static photo mode should not keep a second visible file/folder chooser path",
 );

--- a/web/scripts/test-static-photo-upload-ui-source.mjs
+++ b/web/scripts/test-static-photo-upload-ui-source.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const modalSource = fs.readFileSync(
+  path.resolve("components/NewProjectModal.tsx"),
+  "utf8",
+);
+
+assert.match(
+  modalSource,
+  /<span className="upload-mode-label">Static Photos<\/span>/,
+  "upload mode switcher should use the shortened Static Photos label",
+);
+
+assert.doesNotMatch(
+  modalSource,
+  /Static Property Photos/,
+  "old Static Property Photos label should not be present",
+);
+
+assert.doesNotMatch(
+  modalSource,
+  />\s*Choose Folder\s*</,
+  "static photo mode should not render an extra Choose Folder button",
+);
+
+assert.doesNotMatch(
+  modalSource,
+  /staticFilesInputHidden/,
+  "static photo mode should not keep a second visible file/folder chooser path",
+);
+
+assert.match(
+  modalSource,
+  /uploadMode === 'static_photos' \? 'staticFolderInputHidden' : 'fileInputHidden'/,
+  "clicking the upload zone should open the hidden folder input in static photo mode",
+);
+
+assert.match(
+  modalSource,
+  /webkitdirectory: '', directory: ''/,
+  "static photo folder upload input should preserve folder selection support",
+);
+
+console.log("OK static photo upload UI source matches expected chooser behavior");

--- a/web/trigger-dev-build.txt
+++ b/web/trigger-dev-build.txt
@@ -67,3 +67,4 @@
 2026-05-01T15:15:00Z trigger static property photo upload preview
 
 2026-05-04 static photo upload mode switcher polish
+2026-05-05 static photo upload mode switcher minimalist polish

--- a/web/trigger-dev-build.txt
+++ b/web/trigger-dev-build.txt
@@ -72,3 +72,5 @@
 2026-05-05 static photo upload mode switcher tighter pill
 
 2026-05-05 remove static photo choose folder button
+
+2026-05-05 rename static photo toggle label

--- a/web/trigger-dev-build.txt
+++ b/web/trigger-dev-build.txt
@@ -70,3 +70,5 @@
 2026-05-05 static photo upload mode switcher minimalist polish
 
 2026-05-05 static photo upload mode switcher tighter pill
+
+2026-05-05 remove static photo choose folder button

--- a/web/trigger-dev-build.txt
+++ b/web/trigger-dev-build.txt
@@ -68,3 +68,5 @@
 
 2026-05-04 static photo upload mode switcher polish
 2026-05-05 static photo upload mode switcher minimalist polish
+
+2026-05-05 static photo upload mode switcher tighter pill

--- a/web/trigger-dev-build.txt
+++ b/web/trigger-dev-build.txt
@@ -65,3 +65,5 @@
 2026-03-30T13:07:44Z rerun preview auth opt-in with serialized non-production auth API endpoint migrations
 2026-04-17T00:00:00Z validate shared preview backend/role reuse for IAM quota-safe branch deploys
 2026-05-01T15:15:00Z trigger static property photo upload preview
+
+2026-05-04 static photo upload mode switcher polish

--- a/web/trigger-dev-build.txt
+++ b/web/trigger-dev-build.txt
@@ -64,3 +64,4 @@
 2026-03-30T13:01:24Z rerun preview auth opt-in after recovering SpaceportAuthStagingStack rollback state
 2026-03-30T13:07:44Z rerun preview auth opt-in with serialized non-production auth API endpoint migrations
 2026-04-17T00:00:00Z validate shared preview backend/role reuse for IAM quota-safe branch deploys
+2026-05-01T15:15:00Z trigger static property photo upload preview


### PR DESCRIPTION
## Summary
- add Static Property Photos mode to the existing project upload modal
- add authenticated project-scoped R2 presigned upload URL endpoint
- persist photoLibrary metadata with folder paths, file metadata, public URLs, and copyable links
- allow tap-dot photo configs to use full public image URLs

## Verification
- python3 -m unittest tests.unit.test_static_photo_uploads
- python3 -m py_compile infrastructure/spaceport_cdk/lambda/projects/lambda_function.py infrastructure/spaceport_cdk/spaceport_cdk/auth_stack.py
- cd web && node scripts/test-canyon-photo-url-pass-through.mjs
- cd web && NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_SKIP_WEBPACK_CACHE=1 npm run build
- CDK Deploy: https://github.com/HansenHomeAI/v0-spaceport-website/actions/runs/25219854109
- Pages Deploy: https://github.com/HansenHomeAI/v0-spaceport-website/actions/runs/25219854094
- Preview: https://agent-76291438-static-photo.v0-spaceport-website-preview2.pages.dev

## Notes
- Local build completed despite machine-level ENOSPC warnings while webpack tried to write cache files.
- Static photo uploads require R2_PUBLIC_BASE_URL to be configured in the deploy environment.